### PR TITLE
Add Docker Compose local development stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,13 @@ help:
 # Start the development stack
 up:
 	@echo "Starting services..."
-	docker-compose -f deploy/docker-compose.yml up -d
-	@echo "Waiting for services to be healthy..."
-	@sleep 5
-	@echo "Services started."
+	docker compose -f deploy/docker-compose.yml up -d --wait
+	@echo "Services started and healthy."
 
 # Stop and clean up
 down:
 	@echo "Stopping services..."
-	docker-compose -f deploy/docker-compose.yml down -v
+	docker compose -f deploy/docker-compose.yml down -v
 
 # Run unit tests
 test:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,130 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: shisa
+      POSTGRES_PASSWORD: shisa
+      POSTGRES_DB: shisa
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./postgres-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U shisa -d shisa"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - shisa
+
+  nats:
+    image: nats:2.11-alpine
+    command: ["nats-server", "--config", "/etc/nats/nats.conf"]
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    volumes:
+      - natsdata:/data
+      - ./nats.conf:/etc/nats/nats.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8222/healthz || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - shisa
+
+  prometheus:
+    image: prom/prometheus:v3.2.0
+    ports:
+      - "9090:9090"
+    volumes:
+      - promdata:/prometheus
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:9090/-/healthy || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - shisa
+
+  loki:
+    image: grafana/loki:3.4.0
+    ports:
+      - "3100:3100"
+    volumes:
+      - lokidata:/loki
+      - ./loki.yml:/etc/loki/local-config.yaml:ro
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - shisa
+
+  tempo:
+    image: grafana/tempo:2.7.0
+    ports:
+      - "4317:4317"
+      - "3200:3200"
+    volumes:
+      - tempodata:/var/tempo
+      - ./tempo.yml:/etc/tempo/tempo.yaml:ro
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3200/ready || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - shisa
+
+  grafana:
+    image: grafana/grafana:11.6.0
+    ports:
+      - "3000:3000"
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    volumes:
+      - grafanadata:/var/lib/grafana
+      - ./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+    depends_on:
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+      tempo:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - shisa
+
+volumes:
+  pgdata:
+  natsdata:
+  promdata:
+  grafanadata:
+  lokidata:
+  tempodata:
+
+networks:
+  shisa:
+    driver: bridge

--- a/deploy/grafana/datasources.yml
+++ b/deploy/grafana/datasources.yml
@@ -1,0 +1,26 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+      nodeGraph:
+        enabled: true

--- a/deploy/loki.yml
+++ b/deploy/loki.yml
@@ -1,0 +1,25 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h

--- a/deploy/nats.conf
+++ b/deploy/nats.conf
@@ -1,0 +1,11 @@
+# NATS Server Configuration — Shisa Local Development
+
+listen: 0.0.0.0:4222
+
+http_port: 8222
+
+jetstream {
+  store_dir: /data/jetstream
+  max_mem: 256MB
+  max_file: 1GB
+}

--- a/deploy/postgres-init.sql
+++ b/deploy/postgres-init.sql
@@ -1,0 +1,5 @@
+-- Initialize Shisa database extensions.
+-- The 'shisa' database and user are created by POSTGRES_DB / POSTGRES_USER env vars.
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";

--- a/deploy/prometheus.yml
+++ b/deploy/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "trading"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["host.docker.internal:9091"]
+
+  - job_name: "platform"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["host.docker.internal:9092"]
+
+  - job_name: "settlement"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["host.docker.internal:9093"]
+
+  - job_name: "indexer"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["host.docker.internal:9094"]

--- a/deploy/tempo.yml
+++ b/deploy/tempo.yml
@@ -1,0 +1,21 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+metrics_generator:
+  storage:
+    path: /var/tempo/generator/wal


### PR DESCRIPTION
## Summary
- Add `deploy/docker-compose.yml` with 6 infrastructure services: PostgreSQL 16, NATS (JetStream), Prometheus, Grafana, Loki, and Tempo
- All services have health checks (healthy within ~30s), named volumes, and run on an explicit `shisa` bridge network
- Auto-provisioned Grafana datasources (Prometheus, Loki, Tempo with trace-to-logs)
- Prometheus scrape configs for 4 service metrics ports (trading:9091, platform:9092, settlement:9093, indexer:9094)
- Update Makefile `up`/`down` targets to use `docker compose` v2 with `--wait` flag

## Test Plan
- [x] `make up` starts all 6 services, all report healthy
- [x] Health endpoints verified: NATS (:8222), Prometheus (:9090), Grafana (:3000), Loki (:3100), Tempo (:3200)
- [x] Grafana datasources auto-provisioned (Prometheus, Loki, Tempo)
- [x] `make down` cleanly removes all containers, volumes, and network

Closes #2