### PR TITLE
Update begin-task skill to check for open blockers

### DIFF
--- a/.claude/skills/begin-task/SKILL.md
+++ b/.claude/skills/begin-task/SKILL.md
@@ -11,10 +11,20 @@ arguments:
 # Begin Task
 
 1. Read the GitHub issue: `gh issue view {issue_number} --repo Shisa-Fosho/services`
-2. Parse the issue title to derive a branch name: `{issue_number}-{short-kebab-description}`
-3. Ensure working tree is clean: `git status --porcelain`
-4. Create and checkout branch: `git checkout -b {branch_name}`
-5. Enter plan mode to discuss approach before writing code
+2. **Check for blocking dependencies** before proceeding:
+   - Parse the issue body for "blocked-by" or "blocked by" references to other issues (e.g., `#4`, `#7`)
+   - For each blocker, run `gh issue view {blocker_number} --repo Shisa-Fosho/services --json state,title,number` to check if it's still open
+   - If ANY blockers are still **open**, warn the developer clearly:
+     ```
+     ⚠ BLOCKERS DETECTED — this issue has open dependencies:
+       • #{number} "{title}" (state: OPEN)
+     ```
+   - Ask the developer whether to proceed anyway (they may have a stub/workaround strategy) or switch to working on a blocker first. Do NOT silently continue.
+   - If all blockers are closed, note this and proceed normally.
+3. Parse the issue title to derive a branch name: `{issue_number}-{short-kebab-description}`
+4. Ensure working tree is clean: `git status --porcelain`
+5. Create and checkout branch from main: `git checkout main && git pull && git checkout -b {branch_name}`
+6. Enter plan mode to discuss approach before writing code
 
 Branch naming examples:
 - Issue #12 "CLOB matching engine" → `12-clob-matching-engine`


### PR DESCRIPTION
## Summary
- begin-task skill now checks the issue body for `blocked-by` references before creating a branch
- For each blocker, verifies whether the issue is still open via `gh issue view`
- If any blockers are open, warns the developer and asks whether to proceed or switch to a blocker first
- Fixed branch creation to checkout `main` and pull before branching (avoids branching from stale feature branches)

## Test plan
- [ ] Run `/begin-task 6` — should warn that P2 (#7) is an open blocker
- [ ] Run `/begin-task 7` — should show no blockers (P1 #5 and C1 are closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)