### PR TITLE
Update begin-task skill to move issue to In Progress

### DIFF
--- a/.claude/skills/begin-task/SKILL.md
+++ b/.claude/skills/begin-task/SKILL.md
@@ -24,7 +24,11 @@ arguments:
 3. Parse the issue title to derive a branch name: `{issue_number}-{short-kebab-description}`
 4. Ensure working tree is clean: `git status --porcelain`
 5. Create and checkout branch from main: `git checkout main && git pull && git checkout -b {branch_name}`
-6. Enter plan mode to discuss approach before writing code
+6. Move the issue to "In Progress" on the project board and assign it:
+   - `gh issue edit {issue_number} --repo Shisa-Fosho/services --add-assignee @me`
+   - Move to In Progress: `gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id {item_id} --field-id PVTSSF_lADOEC3v5M4BUX8izhBgiFs --single-select-option-id 47fc9ee4`
+   - To get the item ID, run: `gh project item-list 2 --owner Shisa-Fosho --format json --limit 50 | node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8')); const i=d.items.find(x=>x.title.includes('{issue_title_fragment}')); if(i) console.log(i.id); else console.error('item not found');"`
+7. Enter plan mode to discuss approach before writing code
 
 Branch naming examples:
 - Issue #12 "CLOB matching engine" → `12-clob-matching-engine`


### PR DESCRIPTION
## Summary
- begin-task now **assigns the issue** to the current user (`--add-assignee @me`) and **moves it to "In Progress"** on the Shisa Build Order project board before entering plan mode
- Ensures the project board reflects active work and ownership as soon as a developer starts a task

## Test plan
- [ ] Run `/begin-task 7` — verify issue #7 gets assigned to you and moves to In Progress on the project board

🤖 Generated with [Claude Code](https://claude.com/claude-code)