### PR TITLE
Add 800 LOC size check to begin-task planning phase

### DIFF
--- a/.claude/skills/begin-task/SKILL.md
+++ b/.claude/skills/begin-task/SKILL.md
@@ -29,6 +29,18 @@ arguments:
    - Move to In Progress: `gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id {item_id} --field-id PVTSSF_lADOEC3v5M4BUX8izhBgiFs --single-select-option-id 47fc9ee4`
    - To get the item ID, run: `gh project item-list 2 --owner Shisa-Fosho --format json --limit 50 | node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8')); const i=d.items.find(x=>x.title.includes('{issue_title_fragment}')); if(i) console.log(i.id); else console.error('item not found');"`
 7. Enter plan mode to discuss approach before writing code
+8. **Size check (during planning):** After exploring the codebase and designing the implementation, estimate the total hand-written LOC (excluding generated code and tests). The target is **≤ 800 LOC of production code per PR**.
+   - If the estimate exceeds 800 LOC, do NOT proceed with a single large implementation. Instead:
+     ```
+     ⚠ SIZE LIMIT — estimated ~{N} LOC exceeds the 800 LOC target.
+     Proposed split into sub-issues:
+       1. "{sub-issue title}" (~{LOC} LOC) — {one-line scope}
+       2. "{sub-issue title}" (~{LOC} LOC) — {one-line scope}
+       ...
+     ```
+   - Present the split plan to the developer for approval. Each sub-issue should be independently mergeable and testable.
+   - On approval, create the sub-issues via `gh issue create` with the parent issue referenced, then proceed with the first sub-issue only.
+   - If the developer prefers to keep it as one PR, proceed but note the exception.
 
 Branch naming examples:
 - Issue #12 "CLOB matching engine" → `12-clob-matching-engine`


### PR DESCRIPTION
## Summary
- During planning, begin-task now estimates total production LOC (excluding generated code and tests)
- If the estimate exceeds **800 LOC**, it warns the developer and proposes splitting into independently mergeable sub-issues
- Developer can approve the split (sub-issues created automatically) or override to keep a single PR
- Keeps PRs reviewable and catches scope creep early in the planning phase

## Test plan
- [ ] Run `/begin-task` on a large issue — verify the size warning triggers and split proposal is presented
- [ ] Run `/begin-task` on a small issue — verify it proceeds without warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)