### PR TITLE
Add nginx reverse proxy for single-address API routing

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -117,6 +117,26 @@ services:
     networks:
       - shisa
 
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "8000:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      trading:
+        condition: service_healthy
+      platform:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:80/ || exit 0"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    networks:
+      - shisa
+
   trading:
     build:
       context: ..
@@ -125,7 +145,6 @@ services:
         SERVICE: trading
     ports:
       - "9001:9001"
-      - "8080:8080"
       - "9091:9091"
     environment:
       DATABASE_URL: postgres://shisa:shisa@postgres:5432/shisa?sslmode=disable
@@ -156,7 +175,6 @@ services:
         SERVICE: platform
     ports:
       - "9002:9002"
-      - "8081:8081"
       - "9092:9092"
     environment:
       DATABASE_URL: postgres://shisa:shisa@postgres:5432/shisa?sslmode=disable

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,57 @@
+upstream platform {
+    server platform:8081;
+}
+
+upstream trading {
+    server trading:8080;
+}
+
+server {
+    listen 80;
+
+    # Forward client IP information to upstreams.
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Platform service routes.
+    location /auth/ {
+        proxy_pass http://platform;
+    }
+
+    location /admin/ {
+        proxy_pass http://platform;
+    }
+
+    location /markets/ {
+        proxy_pass http://platform;
+    }
+
+    location /data/ {
+        proxy_pass http://platform;
+    }
+
+    # Trading service routes.
+    location /orders/ {
+        proxy_pass http://trading;
+    }
+
+    location /book/ {
+        proxy_pass http://trading;
+    }
+
+    # WebSocket — must forward Upgrade/Connection headers so nginx
+    # performs the HTTP→WS protocol switch rather than buffering.
+    location /ws {
+        proxy_pass http://trading;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Keep the tunnel open during quiet periods.
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}


### PR DESCRIPTION
Closes #39

## Summary

- Adds `deploy/nginx.conf` — upstream blocks for `platform:8081` and `trading:8080`; location blocks routing each path prefix to the correct upstream; WebSocket-aware proxy config for `/ws` (HTTP 1.1 + `Upgrade`/`Connection` headers, 1-hour read/write timeout)
- Adds `nginx` service to `docker-compose.yml` using `nginx:1.27-alpine`, exposing only port **8000** externally; depends on `trading` and `platform` being healthy
- Removes direct host port bindings for `8080` (trading) and `8081` (platform) — they remain reachable inside the `shisa` Docker network but are no longer exposed to the host machine

## Test Plan

- `make up` — confirm nginx starts after trading and platform are healthy
- `curl http://localhost:8000/markets/` → 200/404 from platform (not connection refused)
- `curl http://localhost:8000/orders/` → 200/404 from trading
- WebSocket client connects to `ws://localhost:8000/ws` — confirm handshake completes
- `curl http://localhost:8080` → connection refused (port no longer exposed)
- `curl http://localhost:8081` → connection refused (port no longer exposed)