### PR TITLE
Auth middleware with HMAC verification and JWT fallback

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -73,7 +73,9 @@
       "Bash(xargs cat:*)",
       "Read(//dev/**)",
       "Bash(grep:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(golangci-lint run:*)",
+      "Bash(goimports:*)"
     ]
   },
   "outputStyle": "Learning"

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -75,7 +75,8 @@
       "Bash(grep:*)",
       "Bash(find:*)",
       "Bash(golangci-lint run:*)",
-      "Bash(goimports:*)"
+      "Bash(goimports:*)",
+      "Bash(gh search:*)"
     ]
   },
   "outputStyle": "Learning"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,10 +253,55 @@ Every service follows this structure in `cmd/<service>/main.go`:
 
 ## Polymarket Compatibility
 
-Our REST API aims for compatibility with Polymarket's CLOB client SDKs:
-- TypeScript: `Polymarket/clob-client`
-- Python: `Polymarket/py-clob-client`
-- Order signing: `Polymarket/clob-order-utils`
+Our REST API aims for compatibility with Polymarket's CLOB client SDKs. The
+upstream SDK source is the **authoritative spec** — not general knowledge,
+not prior implementations, not pattern-matching from similar systems.
+
+### Pinned reference versions
+
+| Repo | Pinned tag | Purpose |
+|------|-----------|---------|
+| `Polymarket/clob-client` | `v5.8.2` | TypeScript SDK — auth headers, request signing, REST client |
+| `Polymarket/py-clob-client` | `v0.34.6` | Python SDK — cross-reference for TS |
+| `Polymarket/clob-order-utils` | `main` | Order signing primitives (pin when stable) |
+
+Bump these versions intentionally when you decide to upgrade compatibility
+target. Do not drift — if planning work references a newer behavior, pin
+higher first.
+
+### SDK verification rule
+
+Before planning or implementing any Polymarket-compatible surface (auth
+headers, order signing, REST endpoints, response formats):
+
+1. **Fetch the source from the pinned tag.** Use `gh api` so the fetch is
+   reproducible and tied to a specific commit:
+   ```bash
+   # List directory:
+   gh api repos/Polymarket/clob-client/contents/src/headers?ref=v5.8.2 --jq '.[].name'
+
+   # Read a file:
+   gh api repos/Polymarket/clob-client/contents/src/headers/index.ts?ref=v5.8.2 \
+     --jq '.content' | base64 -d
+   ```
+2. **Extract the exact contract** — header names, field names, types, ordering,
+   signing payload format — and document it in the plan.
+3. **Derive tests from SDK behavior, not from the implementation.** Writing
+   both code and tests from your own mental model creates a closed loop
+   where the tests validate the wrong assumption. Tests must assert what
+   a real SDK client sends and expects, including the **absence** of fields
+   the SDK doesn't use.
+4. **Cross-reference both SDKs** when one is ambiguous. If `clob-client` (TS)
+   and `py-clob-client` (Python) disagree, flag it to the user rather than
+   picking one silently.
+
+### Why this matters (incident log)
+
+- **PR #48 (nonce tracker)**: first implementation added an in-memory nonce
+  tracker keyed on a `POLY_NONCE` header for HMAC-signed requests. The actual
+  clob-client L2 headers don't send `POLY_NONCE` — it's only used on L1
+  (EIP-712) headers. Caught in review by fetching the SDK source; the entire
+  nonce subsystem was removed. Rule exists to prevent recurrence.
 
 ## Contracts (Read-Only Reference)
 

--- a/internal/data/domain.go
+++ b/internal/data/domain.go
@@ -96,6 +96,7 @@ type APIKey struct {
 	KeyHash             string    `db:"key_hash"`              // SHA-256 of the raw API key, hex-encoded. PK.
 	UserAddress         string    `db:"user_address"`          // FK to users.address.
 	HMACSecretEncrypted string    `db:"hmac_secret_encrypted"` // AES-256-GCM ciphertext.
+	PassphraseHash      string    `db:"passphrase_hash"`       // SHA-256 of the passphrase, hex-encoded.
 	Label               string    `db:"label"`
 	ExpiresAt           time.Time `db:"expires_at"`
 	Revoked             bool      `db:"revoked"`

--- a/internal/data/pg_repository.go
+++ b/internal/data/pg_repository.go
@@ -203,12 +203,12 @@ func (r *PGRepository) UpsertAPIKey(ctx context.Context, key *APIKey) error {
 		return fmt.Errorf("upserting api key: %w", err)
 	}
 	_, err := r.pool.Exec(ctx,
-		`INSERT INTO api_keys (key_hash, user_address, hmac_secret_encrypted, label, expires_at)
-		 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO api_keys (key_hash, user_address, hmac_secret_encrypted, passphrase_hash, label, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)
 		 ON CONFLICT (key_hash)
-		 DO UPDATE SET expires_at = $5, hmac_secret_encrypted = $3
+		 DO UPDATE SET expires_at = $6, hmac_secret_encrypted = $3, passphrase_hash = $4
 		 WHERE api_keys.user_address = $2`,
-		key.KeyHash, key.UserAddress, key.HMACSecretEncrypted, key.Label, key.ExpiresAt,
+		key.KeyHash, key.UserAddress, key.HMACSecretEncrypted, key.PassphraseHash, key.Label, key.ExpiresAt,
 	)
 	if err != nil {
 		return fmt.Errorf("upserting api key for %s: %w", key.UserAddress, err)

--- a/internal/data/pg_repository.go
+++ b/internal/data/pg_repository.go
@@ -216,6 +216,26 @@ func (r *PGRepository) UpsertAPIKey(ctx context.Context, key *APIKey) error {
 	return nil
 }
 
+// GetAPIKeyByHash retrieves a single non-revoked, non-expired API key by its hash.
+func (r *PGRepository) GetAPIKeyByHash(ctx context.Context, keyHash string) (*APIKey, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT * FROM api_keys
+		 WHERE key_hash = $1 AND revoked = false AND expires_at > now()`,
+		keyHash,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting api key by hash: %w", err)
+	}
+	key, err := pgx.CollectExactlyOneRow(rows, pgx.RowToAddrOfStructByName[APIKey])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("scanning api key by hash: %w", err)
+	}
+	return key, nil
+}
+
 // GetAPIKeysByUser returns all non-revoked, non-expired API keys for a user.
 func (r *PGRepository) GetAPIKeysByUser(ctx context.Context, userAddress string) ([]*APIKey, error) {
 	rows, err := r.pool.Query(ctx,

--- a/internal/data/repository.go
+++ b/internal/data/repository.go
@@ -49,6 +49,10 @@ type Repository interface {
 	// Validates input via ValidateAPIKey before persisting.
 	UpsertAPIKey(ctx context.Context, key *APIKey) error
 
+	// GetAPIKeyByHash retrieves a single non-revoked, non-expired API key by its hash.
+	// Returns ErrNotFound if the key does not exist, is revoked, or is expired.
+	GetAPIKeyByHash(ctx context.Context, keyHash string) (*APIKey, error)
+
 	// GetAPIKeysByUser returns all non-revoked, non-expired API keys for a user.
 	GetAPIKeysByUser(ctx context.Context, userAddress string) ([]*APIKey, error)
 

--- a/internal/data/validate.go
+++ b/internal/data/validate.go
@@ -40,6 +40,9 @@ func ValidateAPIKey(key *APIKey) error {
 	if key.HMACSecretEncrypted == "" {
 		return fmt.Errorf("encrypted HMAC secret is required: %w", ErrInvalidAPIKey)
 	}
+	if key.PassphraseHash == "" {
+		return fmt.Errorf("passphrase hash is required: %w", ErrInvalidAPIKey)
+	}
 	if key.ExpiresAt.IsZero() {
 		return fmt.Errorf("expiry is required: %w", ErrInvalidAPIKey)
 	}

--- a/internal/platform/auth/apikey.go
+++ b/internal/platform/auth/apikey.go
@@ -123,10 +123,10 @@ func VerifyEIP712Signature(address, timestamp, nonce, message, signature string,
 	return sigBytes, nil
 }
 
-// DeriveAPIKey deterministically derives an API key and HMAC secret from
-// a server-side secret and the user's EIP-712 signature bytes.
+// DeriveAPIKey deterministically derives an API key, HMAC secret, and
+// passphrase from a server-side secret and the user's EIP-712 signature bytes.
 // Same inputs always produce the same outputs (idempotent).
-func DeriveAPIKey(secret, sigBytes []byte) (apiKey string, hmacSecret string) {
+func DeriveAPIKey(secret, sigBytes []byte) (apiKey, hmacSecret, passphrase string) {
 	mac1 := hmac.New(sha256.New, secret)
 	mac1.Write(append([]byte("api-key"), sigBytes...))
 	result1 := mac1.Sum(nil)
@@ -135,7 +135,11 @@ func DeriveAPIKey(secret, sigBytes []byte) (apiKey string, hmacSecret string) {
 	mac2.Write(append([]byte("hmac-secret"), sigBytes...))
 	result2 := mac2.Sum(nil)
 
-	return hex.EncodeToString(result1[:16]), hex.EncodeToString(result2)
+	mac3 := hmac.New(sha256.New, secret)
+	mac3.Write(append([]byte("passphrase"), sigBytes...))
+	result3 := mac3.Sum(nil)
+
+	return hex.EncodeToString(result1[:16]), hex.EncodeToString(result2), hex.EncodeToString(result3[:16])
 }
 
 // HashAPIKey returns the hex-encoded SHA-256 hash of an API key.

--- a/internal/platform/auth/apikey_test.go
+++ b/internal/platform/auth/apikey_test.go
@@ -19,14 +19,17 @@ func TestDeriveAPIKey_Deterministic(t *testing.T) {
 		sig[i] = byte(i)
 	}
 
-	key1, secret1 := DeriveAPIKey(testDerivationSecret, sig)
-	key2, secret2 := DeriveAPIKey(testDerivationSecret, sig)
+	key1, secret1, pass1 := DeriveAPIKey(testDerivationSecret, sig)
+	key2, secret2, pass2 := DeriveAPIKey(testDerivationSecret, sig)
 
 	if key1 != key2 {
 		t.Errorf("api keys differ: %q vs %q", key1, key2)
 	}
 	if secret1 != secret2 {
 		t.Errorf("hmac secrets differ: %q vs %q", secret1, secret2)
+	}
+	if pass1 != pass2 {
+		t.Errorf("passphrases differ: %q vs %q", pass1, pass2)
 	}
 }
 
@@ -37,8 +40,8 @@ func TestDeriveAPIKey_DifferentSignatures(t *testing.T) {
 	sig2 := make([]byte, 65)
 	sig2[0] = 0xFF
 
-	key1, secret1 := DeriveAPIKey(testDerivationSecret, sig1)
-	key2, secret2 := DeriveAPIKey(testDerivationSecret, sig2)
+	key1, secret1, pass1 := DeriveAPIKey(testDerivationSecret, sig1)
+	key2, secret2, pass2 := DeriveAPIKey(testDerivationSecret, sig2)
 
 	if key1 == key2 {
 		t.Error("different signatures should produce different api keys")
@@ -46,13 +49,16 @@ func TestDeriveAPIKey_DifferentSignatures(t *testing.T) {
 	if secret1 == secret2 {
 		t.Error("different signatures should produce different hmac secrets")
 	}
+	if pass1 == pass2 {
+		t.Error("different signatures should produce different passphrases")
+	}
 }
 
 func TestDeriveAPIKey_KeyLength(t *testing.T) {
 	t.Parallel()
 
 	sig := make([]byte, 65)
-	key, secret := DeriveAPIKey(testDerivationSecret, sig)
+	key, secret, passphrase := DeriveAPIKey(testDerivationSecret, sig)
 
 	// API key: 16 bytes hex-encoded = 32 chars.
 	if len(key) != 32 {
@@ -62,17 +68,27 @@ func TestDeriveAPIKey_KeyLength(t *testing.T) {
 	if len(secret) != 64 {
 		t.Errorf("hmac secret length = %d, want 64", len(secret))
 	}
+	// Passphrase: 16 bytes hex-encoded = 32 chars.
+	if len(passphrase) != 32 {
+		t.Errorf("passphrase length = %d, want 32", len(passphrase))
+	}
 }
 
 func TestDeriveAPIKey_KeyAndSecretDiffer(t *testing.T) {
 	t.Parallel()
 
 	sig := make([]byte, 65)
-	key, secret := DeriveAPIKey(testDerivationSecret, sig)
+	key, secret, passphrase := DeriveAPIKey(testDerivationSecret, sig)
 
-	// The API key should not be a prefix of the HMAC secret (different derivations).
+	// The three credentials must be distinct.
 	if secret[:32] == key {
 		t.Error("api key should not equal the first half of hmac secret")
+	}
+	if passphrase == key {
+		t.Error("passphrase should not equal api key")
+	}
+	if passphrase == secret[:32] {
+		t.Error("passphrase should not equal first half of hmac secret")
 	}
 }
 

--- a/internal/platform/auth/handler.go
+++ b/internal/platform/auth/handler.go
@@ -272,6 +272,7 @@ type deriveAPIKeyRequest struct {
 type deriveAPIKeyResponse struct {
 	APIKey     string    `json:"api_key"`
 	HMACSecret string    `json:"hmac_secret"`
+	Passphrase string    `json:"passphrase"`
 	ExpiresAt  time.Time `json:"expires_at"`
 }
 
@@ -298,7 +299,7 @@ func (h *Handler) deriveAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apiKey, hmacSecret := DeriveAPIKey(h.apiKeyCfg.DerivationSecret, sigBytes)
+	apiKey, hmacSecret, passphrase := DeriveAPIKey(h.apiKeyCfg.DerivationSecret, sigBytes)
 	keyHash := HashAPIKey(apiKey)
 
 	encryptedSecret, err := EncryptSecret(h.apiKeyCfg.EncryptionKey, hmacSecret)
@@ -312,6 +313,7 @@ func (h *Handler) deriveAPIKey(w http.ResponseWriter, r *http.Request) {
 		KeyHash:             keyHash,
 		UserAddress:         address,
 		HMACSecretEncrypted: encryptedSecret,
+		PassphraseHash:      HashAPIKey(passphrase),
 		ExpiresAt:           expiresAt,
 	}); err != nil {
 		h.internalError(w, "upserting api key", err)
@@ -321,6 +323,7 @@ func (h *Handler) deriveAPIKey(w http.ResponseWriter, r *http.Request) {
 	_ = httputil.EncodeJSON(w, http.StatusOK, deriveAPIKeyResponse{
 		APIKey:     apiKey,
 		HMACSecret: hmacSecret,
+		Passphrase: passphrase,
 		ExpiresAt:  expiresAt,
 	})
 }

--- a/internal/platform/auth/handler_test.go
+++ b/internal/platform/auth/handler_test.go
@@ -521,12 +521,23 @@ func TestDeriveAPIKey_HappyPath(t *testing.T) {
 	if resp.HMACSecret == "" {
 		t.Error("expected non-empty hmac_secret")
 	}
+	if resp.Passphrase == "" {
+		t.Error("expected non-empty passphrase")
+	}
 	if resp.ExpiresAt.IsZero() {
 		t.Error("expected non-zero expires_at")
 	}
 	// Key should be persisted in the repo.
 	if len(repo.apiKeys) != 1 {
 		t.Errorf("repo apiKeys count = %d, want 1", len(repo.apiKeys))
+	}
+	// Stored passphrase_hash must match the SHA-256 of the returned plaintext passphrase.
+	stored := repo.apiKeys[HashAPIKey(resp.APIKey)]
+	if stored == nil {
+		t.Fatal("derived key not stored")
+	}
+	if stored.PassphraseHash != HashAPIKey(resp.Passphrase) {
+		t.Error("stored passphrase hash does not match hash of returned passphrase")
 	}
 }
 
@@ -603,6 +614,9 @@ func TestDeriveAPIKey_Idempotent(t *testing.T) {
 	}
 	if r1.HMACSecret != r2.HMACSecret {
 		t.Errorf("hmac_secret differs across calls: %q vs %q", r1.HMACSecret, r2.HMACSecret)
+	}
+	if r1.Passphrase != r2.Passphrase {
+		t.Errorf("passphrase differs across calls: %q vs %q", r1.Passphrase, r2.Passphrase)
 	}
 }
 

--- a/internal/platform/auth/handler_test.go
+++ b/internal/platform/auth/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap/zaptest"
 
@@ -106,6 +107,14 @@ func (r *fakeRepo) RevokeAllRefreshTokens(_ context.Context, userAddress string)
 		}
 	}
 	return nil
+}
+
+func (r *fakeRepo) GetAPIKeyByHash(_ context.Context, keyHash string) (*data.APIKey, error) {
+	k, ok := r.apiKeys[keyHash]
+	if !ok || k.Revoked || k.ExpiresAt.Before(time.Now()) {
+		return nil, data.ErrNotFound
+	}
+	return k, nil
 }
 
 func (r *fakeRepo) UpsertAPIKey(_ context.Context, key *data.APIKey) error {

--- a/internal/platform/auth/middleware.go
+++ b/internal/platform/auth/middleware.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -20,13 +19,14 @@ import (
 
 // Polymarket-compatible request headers for API key authentication.
 const (
-	HeaderAPIKey    = "POLY_API_KEY" //nolint:gosec // header name, not a credential
-	HeaderSignature = "POLY_SIGNATURE"
-	HeaderTimestamp = "POLY_TIMESTAMP"
-	HeaderNonce     = "POLY_NONCE"
+	HeaderAPIKey     = "POLY_API_KEY" //nolint:gosec // header name, not a credential
+	HeaderSignature  = "POLY_SIGNATURE"
+	HeaderTimestamp  = "POLY_TIMESTAMP"
+	HeaderPassphrase = "POLY_PASSPHRASE"
 )
 
 // maxTimestampDrift is the maximum allowed age of a signed request.
+// Replay protection within this window is accepted as a Polymarket-compatible trade-off.
 const maxTimestampDrift = 5 * time.Second
 
 // Authenticate returns HTTP middleware that validates the Authorization
@@ -49,12 +49,12 @@ func Authenticate(jwtMgr *JWTManager) func(http.Handler) http.Handler {
 // Middleware returns HTTP middleware that authenticates requests using
 // either HMAC-signed API keys (checked first) or JWT bearer tokens (fallback).
 // On success it injects the authenticated user address into the request context.
-func Middleware(jwtMgr *JWTManager, repo data.Repository, encryptionKey []byte, nonces *NonceTracker, logger *zap.Logger) func(http.Handler) http.Handler {
+func Middleware(jwtMgr *JWTManager, repo data.Repository, encryptionKey []byte, logger *zap.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Try API key auth first.
 			if apiKey := r.Header.Get(HeaderAPIKey); apiKey != "" {
-				address, ok := authenticateAPIKey(w, r, apiKey, repo, encryptionKey, nonces, logger)
+				address, ok := authenticateAPIKey(w, r, apiKey, repo, encryptionKey, logger)
 				if !ok {
 					return // response already written
 				}
@@ -105,10 +105,9 @@ func authenticateJWT(w http.ResponseWriter, r *http.Request, jwtMgr *JWTManager)
 
 // authenticateAPIKey validates an HMAC-signed API key request. Returns the
 // user address on success, or writes a 401 response and returns false.
-func authenticateAPIKey(w http.ResponseWriter, r *http.Request, apiKey string, repo data.Repository, encryptionKey []byte, nonces *NonceTracker, logger *zap.Logger) (string, bool) {
+func authenticateAPIKey(w http.ResponseWriter, r *http.Request, apiKey string, repo data.Repository, encryptionKey []byte, logger *zap.Logger) (string, bool) {
 	timestamp := r.Header.Get(HeaderTimestamp)
 	signature := r.Header.Get(HeaderSignature)
-	nonce := r.Header.Get(HeaderNonce)
 
 	if timestamp == "" || signature == "" {
 		httputil.ErrorResponse(w, http.StatusUnauthorized, "missing signature headers")
@@ -126,19 +125,19 @@ func authenticateAPIKey(w http.ResponseWriter, r *http.Request, apiKey string, r
 		return "", false
 	}
 
-	// Check nonce replay.
-	nonceKey := apiKey + ":" + nonce + ":" + timestamp
-	if !nonces.Check(nonceKey) {
-		httputil.ErrorResponse(w, http.StatusUnauthorized, "replayed request")
-		return "", false
-	}
-
 	// Look up API key.
 	keyHash := HashAPIKey(apiKey)
 	stored, err := repo.GetAPIKeyByHash(r.Context(), keyHash)
 	if err != nil {
 		logger.Debug("api key lookup failed", zap.Error(err))
 		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid api key")
+		return "", false
+	}
+
+	// Verify passphrase (second factor alongside HMAC secret).
+	passphrase := r.Header.Get(HeaderPassphrase)
+	if !hmac.Equal([]byte(HashAPIKey(passphrase)), []byte(stored.PassphraseHash)) {
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid passphrase")
 		return "", false
 	}
 
@@ -176,62 +175,4 @@ func VerifyHMACSignature(secret, timestamp, method, path, body, signature string
 	mac.Write([]byte(BuildHMACMessage(timestamp, method, path, body)))
 	expected := hex.EncodeToString(mac.Sum(nil))
 	return hmac.Equal([]byte(expected), []byte(signature))
-}
-
-// --- Nonce replay protection ---
-
-// NonceTracker prevents replay of signed API key requests. It stores seen
-// nonces in memory and periodically cleans up expired entries.
-type NonceTracker struct {
-	mu   sync.Mutex
-	seen map[string]time.Time
-	done chan struct{}
-}
-
-// NewNonceTracker creates a NonceTracker and starts background cleanup.
-func NewNonceTracker() *NonceTracker {
-	nt := &NonceTracker{
-		seen: make(map[string]time.Time),
-		done: make(chan struct{}),
-	}
-	go nt.cleanup()
-	return nt
-}
-
-// Check returns true if the nonce has not been seen before, and records it.
-// Returns false for replayed nonces.
-func (nt *NonceTracker) Check(nonce string) bool {
-	nt.mu.Lock()
-	defer nt.mu.Unlock()
-	if _, exists := nt.seen[nonce]; exists {
-		return false
-	}
-	nt.seen[nonce] = time.Now()
-	return true
-}
-
-// Stop shuts down the background cleanup goroutine.
-func (nt *NonceTracker) Stop() {
-	close(nt.done)
-}
-
-// cleanup periodically removes nonces older than twice the drift window.
-func (nt *NonceTracker) cleanup() {
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-nt.done:
-			return
-		case <-ticker.C:
-			nt.mu.Lock()
-			cutoff := time.Now().Add(-2 * maxTimestampDrift)
-			for k, t := range nt.seen {
-				if t.Before(cutoff) {
-					delete(nt.seen, k)
-				}
-			}
-			nt.mu.Unlock()
-		}
-	}
 }

--- a/internal/platform/auth/middleware.go
+++ b/internal/platform/auth/middleware.go
@@ -1,11 +1,33 @@
 package auth
 
 import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
 	"net/http"
+	"strconv"
 	"strings"
+	"sync"
+	"time"
 
+	"go.uber.org/zap"
+
+	"github.com/Shisa-Fosho/services/internal/data"
 	"github.com/Shisa-Fosho/services/internal/platform/httputil"
 )
+
+// Polymarket-compatible request headers for API key authentication.
+const (
+	HeaderAPIKey    = "POLY_API_KEY" //nolint:gosec // header name, not a credential
+	HeaderSignature = "POLY_SIGNATURE"
+	HeaderTimestamp = "POLY_TIMESTAMP"
+	HeaderNonce     = "POLY_NONCE"
+)
+
+// maxTimestampDrift is the maximum allowed age of a signed request.
+const maxTimestampDrift = 5 * time.Second
 
 // Authenticate returns HTTP middleware that validates the Authorization
 // header (Bearer token), verifies the JWT access token, and stores the
@@ -14,26 +36,202 @@ import (
 func Authenticate(jwtMgr *JWTManager) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			header := r.Header.Get("Authorization")
-			if header == "" {
-				httputil.ErrorResponse(w, http.StatusUnauthorized, "missing authorization header")
+			address, ok := authenticateJWT(w, r, jwtMgr)
+			if !ok {
 				return
 			}
-
-			parts := strings.SplitN(header, " ", 2)
-			if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-				httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid authorization header")
-				return
-			}
-
-			claims, err := jwtMgr.ValidateAccessToken(parts[1])
-			if err != nil {
-				httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid token")
-				return
-			}
-
-			ctx := WithUserAddress(r.Context(), claims.Subject)
+			ctx := WithUserAddress(r.Context(), address)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
+	}
+}
+
+// Middleware returns HTTP middleware that authenticates requests using
+// either HMAC-signed API keys (checked first) or JWT bearer tokens (fallback).
+// On success it injects the authenticated user address into the request context.
+func Middleware(jwtMgr *JWTManager, repo data.Repository, encryptionKey []byte, nonces *NonceTracker, logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Try API key auth first.
+			if apiKey := r.Header.Get(HeaderAPIKey); apiKey != "" {
+				address, ok := authenticateAPIKey(w, r, apiKey, repo, encryptionKey, nonces, logger)
+				if !ok {
+					return // response already written
+				}
+				ctx := WithUserAddress(r.Context(), address)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
+			// Fall back to JWT bearer token.
+			if r.Header.Get("Authorization") != "" {
+				address, ok := authenticateJWT(w, r, jwtMgr)
+				if !ok {
+					return
+				}
+				ctx := WithUserAddress(r.Context(), address)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
+			httputil.ErrorResponse(w, http.StatusUnauthorized, "missing credentials")
+		})
+	}
+}
+
+// authenticateJWT extracts and validates a Bearer token from the Authorization
+// header. Returns the user address on success, or writes a 401 and returns false.
+func authenticateJWT(w http.ResponseWriter, r *http.Request, jwtMgr *JWTManager) (string, bool) {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "missing authorization header")
+		return "", false
+	}
+
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid authorization header")
+		return "", false
+	}
+
+	claims, err := jwtMgr.ValidateAccessToken(parts[1])
+	if err != nil {
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid token")
+		return "", false
+	}
+
+	return claims.Subject, true
+}
+
+// authenticateAPIKey validates an HMAC-signed API key request. Returns the
+// user address on success, or writes a 401 response and returns false.
+func authenticateAPIKey(w http.ResponseWriter, r *http.Request, apiKey string, repo data.Repository, encryptionKey []byte, nonces *NonceTracker, logger *zap.Logger) (string, bool) {
+	timestamp := r.Header.Get(HeaderTimestamp)
+	signature := r.Header.Get(HeaderSignature)
+	nonce := r.Header.Get(HeaderNonce)
+
+	if timestamp == "" || signature == "" {
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "missing signature headers")
+		return "", false
+	}
+
+	// Validate timestamp drift.
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid timestamp")
+		return "", false
+	}
+	if drift := time.Since(time.Unix(ts, 0)).Abs(); drift > maxTimestampDrift {
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "timestamp drift too large")
+		return "", false
+	}
+
+	// Check nonce replay.
+	nonceKey := apiKey + ":" + nonce + ":" + timestamp
+	if !nonces.Check(nonceKey) {
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "replayed request")
+		return "", false
+	}
+
+	// Look up API key.
+	keyHash := HashAPIKey(apiKey)
+	stored, err := repo.GetAPIKeyByHash(r.Context(), keyHash)
+	if err != nil {
+		logger.Debug("api key lookup failed", zap.Error(err))
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid api key")
+		return "", false
+	}
+
+	// Decrypt HMAC secret and verify signature.
+	secret, err := DecryptSecret(encryptionKey, stored.HMACSecretEncrypted)
+	if err != nil {
+		logger.Error("decrypting hmac secret", zap.Error(err))
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid api key")
+		return "", false
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		httputil.ErrorResponse(w, http.StatusBadRequest, "failed to read request body")
+		return "", false
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	if !VerifyHMACSignature(secret, timestamp, r.Method, r.URL.Path, string(body), signature) {
+		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid signature")
+		return "", false
+	}
+
+	return stored.UserAddress, true
+}
+
+// BuildHMACMessage constructs the signing payload: timestamp + method + path + body.
+func BuildHMACMessage(timestamp, method, path, body string) string {
+	return timestamp + method + path + body
+}
+
+// VerifyHMACSignature verifies an HMAC-SHA256 signature over the request payload.
+func VerifyHMACSignature(secret, timestamp, method, path, body, signature string) bool {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(BuildHMACMessage(timestamp, method, path, body)))
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(signature))
+}
+
+// --- Nonce replay protection ---
+
+// NonceTracker prevents replay of signed API key requests. It stores seen
+// nonces in memory and periodically cleans up expired entries.
+type NonceTracker struct {
+	mu   sync.Mutex
+	seen map[string]time.Time
+	done chan struct{}
+}
+
+// NewNonceTracker creates a NonceTracker and starts background cleanup.
+func NewNonceTracker() *NonceTracker {
+	nt := &NonceTracker{
+		seen: make(map[string]time.Time),
+		done: make(chan struct{}),
+	}
+	go nt.cleanup()
+	return nt
+}
+
+// Check returns true if the nonce has not been seen before, and records it.
+// Returns false for replayed nonces.
+func (nt *NonceTracker) Check(nonce string) bool {
+	nt.mu.Lock()
+	defer nt.mu.Unlock()
+	if _, exists := nt.seen[nonce]; exists {
+		return false
+	}
+	nt.seen[nonce] = time.Now()
+	return true
+}
+
+// Stop shuts down the background cleanup goroutine.
+func (nt *NonceTracker) Stop() {
+	close(nt.done)
+}
+
+// cleanup periodically removes nonces older than twice the drift window.
+func (nt *NonceTracker) cleanup() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-nt.done:
+			return
+		case <-ticker.C:
+			nt.mu.Lock()
+			cutoff := time.Now().Add(-2 * maxTimestampDrift)
+			for k, t := range nt.seen {
+				if t.Before(cutoff) {
+					delete(nt.seen, k)
+				}
+			}
+			nt.mu.Unlock()
+		}
 	}
 }

--- a/internal/platform/auth/middleware_test.go
+++ b/internal/platform/auth/middleware_test.go
@@ -1,11 +1,22 @@
 package auth
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"go.uber.org/zap/zaptest"
+
+	"github.com/Shisa-Fosho/services/internal/data"
 )
+
+// --- Existing Authenticate (JWT-only) tests ---
 
 func TestAuthenticate_ValidToken(t *testing.T) {
 	t.Parallel()
@@ -90,5 +101,278 @@ func TestAuthenticate_ExpiredToken(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "invalid token") {
 		t.Errorf("body = %q, want 'invalid token'", w.Body.String())
+	}
+}
+
+// --- Combined AuthMiddleware tests ---
+
+// signRequest is a test helper that signs an HTTP request with HMAC-SHA256.
+func signRequest(r *http.Request, apiKey, hmacSecret, body string) {
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	msg := BuildHMACMessage(ts, r.Method, r.URL.Path, body)
+	mac := hmac.New(sha256.New, []byte(hmacSecret))
+	mac.Write([]byte(msg))
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	r.Header.Set(HeaderAPIKey, apiKey)
+	r.Header.Set(HeaderTimestamp, ts)
+	r.Header.Set(HeaderSignature, sig)
+	r.Header.Set(HeaderNonce, "1")
+}
+
+// testAPIKeySetup creates a stored API key and returns (rawKey, hmacSecret, encryptionKey).
+func testAPIKeySetup(t *testing.T, repo *fakeRepo, address string) (string, string, []byte) {
+	t.Helper()
+	encKey := []byte("test-encryption-key-32-bytes!!!!") // exactly 32 bytes
+
+	rawKey := "test-api-key-hex-0123456789abcd"
+	hmacSecret := "test-hmac-secret"
+	keyHash := HashAPIKey(rawKey)
+
+	encrypted, err := EncryptSecret(encKey, hmacSecret)
+	if err != nil {
+		t.Fatalf("encrypting secret: %v", err)
+	}
+
+	repo.apiKeys[keyHash] = &data.APIKey{
+		KeyHash:             keyHash,
+		UserAddress:         address,
+		HMACSecretEncrypted: encrypted,
+		ExpiresAt:           time.Now().Add(24 * time.Hour),
+	}
+
+	return rawKey, hmacSecret, encKey
+}
+
+// newAuthMiddlewareHandler creates a test handler wrapped with AuthMiddleware.
+func newAuthMiddlewareHandler(t *testing.T, repo *fakeRepo, encKey []byte) (http.Handler, *JWTManager, *NonceTracker) {
+	t.Helper()
+	jwtMgr, err := NewJWTManager(testJWTConfig())
+	if err != nil {
+		t.Fatalf("creating JWT manager: %v", err)
+	}
+	logger := zaptest.NewLogger(t)
+	nonces := NewNonceTracker()
+	t.Cleanup(nonces.Stop)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(UserAddressFrom(r.Context())))
+	})
+	handler := Middleware(jwtMgr, repo, encKey, nonces, logger)(inner)
+	return handler, jwtMgr, nonces
+}
+
+func TestAuthMiddleware_ValidAPIKey(t *testing.T) {
+	t.Parallel()
+	addr := "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, addr)
+	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+
+	body := `{"order":"buy"}`
+	r := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(body))
+	signRequest(r, rawKey, hmacSecret, body)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Body.String(); got != addr {
+		t.Errorf("address = %q, want %q", got, addr)
+	}
+}
+
+func TestAuthMiddleware_ValidJWT(t *testing.T) {
+	t.Parallel()
+	addr := "0xcccccccccccccccccccccccccccccccccccccccc"
+	encKey := []byte("test-encryption-key-32-bytes!!!!")
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	handler, jwtMgr, _ := newAuthMiddlewareHandler(t, repo, encKey)
+
+	token, _ := jwtMgr.IssueAccessToken(addr)
+	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Body.String(); got != addr {
+		t.Errorf("address = %q, want %q", got, addr)
+	}
+}
+
+func TestAuthMiddleware_APIKeyTakesPrecedence(t *testing.T) {
+	t.Parallel()
+	apiKeyAddr := "0xcccccccccccccccccccccccccccccccccccccccc"
+	jwtAddr := "0xdddddddddddddddddddddddddddddddddddddd"
+
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, apiKeyAddr)
+	handler, jwtMgr, _ := newAuthMiddlewareHandler(t, repo, encKey)
+	token, _ := jwtMgr.IssueAccessToken(jwtAddr)
+	body := `{"order":"buy"}`
+	r := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+token)
+	signRequest(r, rawKey, hmacSecret, body)
+
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Body.String(); got != apiKeyAddr {
+		t.Errorf("address = %q, want %q", got, apiKeyAddr)
+	}
+
+}
+
+func TestAuthMiddleware_MissingCredentials(t *testing.T) {
+	t.Parallel()
+	encKey := []byte("test-encryption-key-32-bytes!!!!")
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+
+	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(w.Body.String(), "missing credentials") {
+		t.Errorf("body = %q, want 'missing credentials'", w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_TimestampDrift(t *testing.T) {
+	t.Parallel()
+	addr := "0xdddddddddddddddddddddddddddddddddddddd"
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, addr)
+	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+
+	// Use a timestamp 10 seconds in the past.
+	staleTS := strconv.FormatInt(time.Now().Add(-10*time.Second).Unix(), 10)
+	body := ""
+	msg := BuildHMACMessage(staleTS, http.MethodGet, "/orders", body)
+	mac := hmac.New(sha256.New, []byte(hmacSecret))
+	mac.Write([]byte(msg))
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
+	r.Header.Set(HeaderAPIKey, rawKey)
+	r.Header.Set(HeaderTimestamp, staleTS)
+	r.Header.Set(HeaderSignature, sig)
+	r.Header.Set(HeaderNonce, "1")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(w.Body.String(), "timestamp drift") {
+		t.Errorf("body = %q, want 'timestamp drift'", w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_NonceReplay(t *testing.T) {
+	t.Parallel()
+	addr := "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, addr)
+	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+
+	body := ""
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	msg := BuildHMACMessage(ts, http.MethodGet, "/orders", body)
+	mac := hmac.New(sha256.New, []byte(hmacSecret))
+	mac.Write([]byte(msg))
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	makeReq := func() *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/orders", nil)
+		r.Header.Set(HeaderAPIKey, rawKey)
+		r.Header.Set(HeaderTimestamp, ts)
+		r.Header.Set(HeaderSignature, sig)
+		r.Header.Set(HeaderNonce, "same-nonce")
+		return r
+	}
+
+	// First request should succeed.
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, makeReq())
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first request: status = %d, want %d", w1.Code, http.StatusOK)
+	}
+
+	// Second identical request should be rejected.
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, makeReq())
+	if w2.Code != http.StatusUnauthorized {
+		t.Errorf("replay: status = %d, want %d", w2.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(w2.Body.String(), "replayed") {
+		t.Errorf("body = %q, want 'replayed'", w2.Body.String())
+	}
+}
+
+func TestAuthMiddleware_InvalidHMAC(t *testing.T) {
+	t.Parallel()
+	addr := "0xffffffffffffffffffffffffffffffffffffffff"
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	rawKey, _, encKey := testAPIKeySetup(t, repo, addr)
+	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+
+	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
+	r.Header.Set(HeaderAPIKey, rawKey)
+	r.Header.Set(HeaderTimestamp, strconv.FormatInt(time.Now().Unix(), 10))
+	r.Header.Set(HeaderSignature, "bad-signature")
+	r.Header.Set(HeaderNonce, "1")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(w.Body.String(), "invalid signature") {
+		t.Errorf("body = %q, want 'invalid signature'", w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_RevokedKey(t *testing.T) {
+	t.Parallel()
+	addr := "0x1111111111111111111111111111111111111111"
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, addr)
+
+	// Revoke the key.
+	keyHash := HashAPIKey(rawKey)
+	repo.apiKeys[keyHash].Revoked = true
+
+	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+
+	body := ""
+	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
+	signRequest(r, rawKey, hmacSecret, body)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(w.Body.String(), "invalid api key") {
+		t.Errorf("body = %q, want 'invalid api key'", w.Body.String())
 	}
 }

--- a/internal/platform/auth/middleware_test.go
+++ b/internal/platform/auth/middleware_test.go
@@ -107,7 +107,7 @@ func TestAuthenticate_ExpiredToken(t *testing.T) {
 // --- Combined AuthMiddleware tests ---
 
 // signRequest is a test helper that signs an HTTP request with HMAC-SHA256.
-func signRequest(r *http.Request, apiKey, hmacSecret, body string) {
+func signRequest(r *http.Request, apiKey, hmacSecret, passphrase, body string) {
 	ts := strconv.FormatInt(time.Now().Unix(), 10)
 	msg := BuildHMACMessage(ts, r.Method, r.URL.Path, body)
 	mac := hmac.New(sha256.New, []byte(hmacSecret))
@@ -117,16 +117,17 @@ func signRequest(r *http.Request, apiKey, hmacSecret, body string) {
 	r.Header.Set(HeaderAPIKey, apiKey)
 	r.Header.Set(HeaderTimestamp, ts)
 	r.Header.Set(HeaderSignature, sig)
-	r.Header.Set(HeaderNonce, "1")
+	r.Header.Set(HeaderPassphrase, passphrase)
 }
 
-// testAPIKeySetup creates a stored API key and returns (rawKey, hmacSecret, encryptionKey).
-func testAPIKeySetup(t *testing.T, repo *fakeRepo, address string) (string, string, []byte) {
+// testAPIKeySetup creates a stored API key and returns (rawKey, hmacSecret, passphrase, encryptionKey).
+func testAPIKeySetup(t *testing.T, repo *fakeRepo, address string) (string, string, string, []byte) {
 	t.Helper()
 	encKey := []byte("test-encryption-key-32-bytes!!!!") // exactly 32 bytes
 
 	rawKey := "test-api-key-hex-0123456789abcd"
 	hmacSecret := "test-hmac-secret"
+	passphrase := "test-passphrase-0123456789abcdef"
 	keyHash := HashAPIKey(rawKey)
 
 	encrypted, err := EncryptSecret(encKey, hmacSecret)
@@ -138,41 +139,40 @@ func testAPIKeySetup(t *testing.T, repo *fakeRepo, address string) (string, stri
 		KeyHash:             keyHash,
 		UserAddress:         address,
 		HMACSecretEncrypted: encrypted,
+		PassphraseHash:      HashAPIKey(passphrase),
 		ExpiresAt:           time.Now().Add(24 * time.Hour),
 	}
 
-	return rawKey, hmacSecret, encKey
+	return rawKey, hmacSecret, passphrase, encKey
 }
 
 // newAuthMiddlewareHandler creates a test handler wrapped with AuthMiddleware.
-func newAuthMiddlewareHandler(t *testing.T, repo *fakeRepo, encKey []byte) (http.Handler, *JWTManager, *NonceTracker) {
+func newAuthMiddlewareHandler(t *testing.T, repo *fakeRepo, encKey []byte) (http.Handler, *JWTManager) {
 	t.Helper()
 	jwtMgr, err := NewJWTManager(testJWTConfig())
 	if err != nil {
 		t.Fatalf("creating JWT manager: %v", err)
 	}
 	logger := zaptest.NewLogger(t)
-	nonces := NewNonceTracker()
-	t.Cleanup(nonces.Stop)
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(UserAddressFrom(r.Context())))
 	})
-	handler := Middleware(jwtMgr, repo, encKey, nonces, logger)(inner)
-	return handler, jwtMgr, nonces
+	handler := Middleware(jwtMgr, repo, encKey, logger)(inner)
+	return handler, jwtMgr
 }
 
 func TestAuthMiddleware_ValidAPIKey(t *testing.T) {
 	t.Parallel()
 	addr := "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
-	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, addr)
-	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+	rawKey, hmacSecret, passphrase, encKey := testAPIKeySetup(t, repo, addr)
+	handler, _ := newAuthMiddlewareHandler(t, repo, encKey)
 
 	body := `{"order":"buy"}`
 	r := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(body))
-	signRequest(r, rawKey, hmacSecret, body)
+	signRequest(r, rawKey, hmacSecret, passphrase, body)
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, r)
@@ -190,7 +190,7 @@ func TestAuthMiddleware_ValidJWT(t *testing.T) {
 	addr := "0xcccccccccccccccccccccccccccccccccccccccc"
 	encKey := []byte("test-encryption-key-32-bytes!!!!")
 	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
-	handler, jwtMgr, _ := newAuthMiddlewareHandler(t, repo, encKey)
+	handler, jwtMgr := newAuthMiddlewareHandler(t, repo, encKey)
 
 	token, _ := jwtMgr.IssueAccessToken(addr)
 	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
@@ -213,13 +213,13 @@ func TestAuthMiddleware_APIKeyTakesPrecedence(t *testing.T) {
 	jwtAddr := "0xdddddddddddddddddddddddddddddddddddddd"
 
 	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
-	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, apiKeyAddr)
-	handler, jwtMgr, _ := newAuthMiddlewareHandler(t, repo, encKey)
+	rawKey, hmacSecret, passphrase, encKey := testAPIKeySetup(t, repo, apiKeyAddr)
+	handler, jwtMgr := newAuthMiddlewareHandler(t, repo, encKey)
 	token, _ := jwtMgr.IssueAccessToken(jwtAddr)
 	body := `{"order":"buy"}`
 	r := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(body))
 	r.Header.Set("Authorization", "Bearer "+token)
-	signRequest(r, rawKey, hmacSecret, body)
+	signRequest(r, rawKey, hmacSecret, passphrase, body)
 
 	w := httptest.NewRecorder()
 
@@ -238,7 +238,7 @@ func TestAuthMiddleware_MissingCredentials(t *testing.T) {
 	t.Parallel()
 	encKey := []byte("test-encryption-key-32-bytes!!!!")
 	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
-	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+	handler, _ := newAuthMiddlewareHandler(t, repo, encKey)
 
 	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
 	w := httptest.NewRecorder()
@@ -257,8 +257,8 @@ func TestAuthMiddleware_TimestampDrift(t *testing.T) {
 	t.Parallel()
 	addr := "0xdddddddddddddddddddddddddddddddddddddd"
 	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
-	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, addr)
-	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+	rawKey, hmacSecret, _, encKey := testAPIKeySetup(t, repo, addr)
+	handler, _ := newAuthMiddlewareHandler(t, repo, encKey)
 
 	// Use a timestamp 10 seconds in the past.
 	staleTS := strconv.FormatInt(time.Now().Add(-10*time.Second).Unix(), 10)
@@ -272,7 +272,6 @@ func TestAuthMiddleware_TimestampDrift(t *testing.T) {
 	r.Header.Set(HeaderAPIKey, rawKey)
 	r.Header.Set(HeaderTimestamp, staleTS)
 	r.Header.Set(HeaderSignature, sig)
-	r.Header.Set(HeaderNonce, "1")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, r)
@@ -285,59 +284,18 @@ func TestAuthMiddleware_TimestampDrift(t *testing.T) {
 	}
 }
 
-func TestAuthMiddleware_NonceReplay(t *testing.T) {
-	t.Parallel()
-	addr := "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
-	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, addr)
-	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
-
-	body := ""
-	ts := strconv.FormatInt(time.Now().Unix(), 10)
-	msg := BuildHMACMessage(ts, http.MethodGet, "/orders", body)
-	mac := hmac.New(sha256.New, []byte(hmacSecret))
-	mac.Write([]byte(msg))
-	sig := hex.EncodeToString(mac.Sum(nil))
-
-	makeReq := func() *http.Request {
-		r := httptest.NewRequest(http.MethodGet, "/orders", nil)
-		r.Header.Set(HeaderAPIKey, rawKey)
-		r.Header.Set(HeaderTimestamp, ts)
-		r.Header.Set(HeaderSignature, sig)
-		r.Header.Set(HeaderNonce, "same-nonce")
-		return r
-	}
-
-	// First request should succeed.
-	w1 := httptest.NewRecorder()
-	handler.ServeHTTP(w1, makeReq())
-	if w1.Code != http.StatusOK {
-		t.Fatalf("first request: status = %d, want %d", w1.Code, http.StatusOK)
-	}
-
-	// Second identical request should be rejected.
-	w2 := httptest.NewRecorder()
-	handler.ServeHTTP(w2, makeReq())
-	if w2.Code != http.StatusUnauthorized {
-		t.Errorf("replay: status = %d, want %d", w2.Code, http.StatusUnauthorized)
-	}
-	if !strings.Contains(w2.Body.String(), "replayed") {
-		t.Errorf("body = %q, want 'replayed'", w2.Body.String())
-	}
-}
-
 func TestAuthMiddleware_InvalidHMAC(t *testing.T) {
 	t.Parallel()
 	addr := "0xffffffffffffffffffffffffffffffffffffffff"
 	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
-	rawKey, _, encKey := testAPIKeySetup(t, repo, addr)
-	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+	rawKey, _, passphrase, encKey := testAPIKeySetup(t, repo, addr)
+	handler, _ := newAuthMiddlewareHandler(t, repo, encKey)
 
 	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
 	r.Header.Set(HeaderAPIKey, rawKey)
 	r.Header.Set(HeaderTimestamp, strconv.FormatInt(time.Now().Unix(), 10))
 	r.Header.Set(HeaderSignature, "bad-signature")
-	r.Header.Set(HeaderNonce, "1")
+	r.Header.Set(HeaderPassphrase, passphrase)
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, r)
@@ -354,17 +312,17 @@ func TestAuthMiddleware_RevokedKey(t *testing.T) {
 	t.Parallel()
 	addr := "0x1111111111111111111111111111111111111111"
 	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
-	rawKey, hmacSecret, encKey := testAPIKeySetup(t, repo, addr)
+	rawKey, hmacSecret, passphrase, encKey := testAPIKeySetup(t, repo, addr)
 
 	// Revoke the key.
 	keyHash := HashAPIKey(rawKey)
 	repo.apiKeys[keyHash].Revoked = true
 
-	handler, _, _ := newAuthMiddlewareHandler(t, repo, encKey)
+	handler, _ := newAuthMiddlewareHandler(t, repo, encKey)
 
 	body := ""
 	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
-	signRequest(r, rawKey, hmacSecret, body)
+	signRequest(r, rawKey, hmacSecret, passphrase, body)
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, r)
@@ -374,5 +332,58 @@ func TestAuthMiddleware_RevokedKey(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "invalid api key") {
 		t.Errorf("body = %q, want 'invalid api key'", w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_MissingPassphrase(t *testing.T) {
+	t.Parallel()
+	addr := "0x2222222222222222222222222222222222222222"
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	rawKey, hmacSecret, _, encKey := testAPIKeySetup(t, repo, addr)
+	handler, _ := newAuthMiddlewareHandler(t, repo, encKey)
+
+	// Sign the request but omit the passphrase header.
+	body := ""
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	msg := BuildHMACMessage(ts, http.MethodGet, "/orders", body)
+	mac := hmac.New(sha256.New, []byte(hmacSecret))
+	mac.Write([]byte(msg))
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
+	r.Header.Set(HeaderAPIKey, rawKey)
+	r.Header.Set(HeaderTimestamp, ts)
+	r.Header.Set(HeaderSignature, sig)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(w.Body.String(), "invalid passphrase") {
+		t.Errorf("body = %q, want 'invalid passphrase'", w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_WrongPassphrase(t *testing.T) {
+	t.Parallel()
+	addr := "0x3333333333333333333333333333333333333333"
+	repo := &fakeRepo{apiKeys: make(map[string]*data.APIKey)}
+	rawKey, hmacSecret, _, encKey := testAPIKeySetup(t, repo, addr)
+	handler, _ := newAuthMiddlewareHandler(t, repo, encKey)
+
+	body := ""
+	r := httptest.NewRequest(http.MethodGet, "/orders", nil)
+	signRequest(r, rawKey, hmacSecret, "definitely-not-the-right-passphrase", body)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(w.Body.String(), "invalid passphrase") {
+		t.Errorf("body = %q, want 'invalid passphrase'", w.Body.String())
 	}
 }

--- a/migrations/platform/000011_add_api_key_passphrase.down.sql
+++ b/migrations/platform/000011_add_api_key_passphrase.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE api_keys DROP COLUMN passphrase_hash;

--- a/migrations/platform/000011_add_api_key_passphrase.up.sql
+++ b/migrations/platform/000011_add_api_key_passphrase.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE api_keys ADD COLUMN passphrase_hash TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary
- Combined `auth.Middleware` that tries HMAC-signed API key auth first, falls back to JWT bearer tokens, returns 401 if neither present
- HMAC request verification: validates signature over `timestamp + method + path + body`, rejects >5s timestamp drift
- `POLY_PASSPHRASE` support: a third credential derived deterministically from the EIP-712 signature (alongside API key + HMAC secret), stored as SHA-256 hash, verified in constant time on each request
- `GetAPIKeyByHash` repository method for API key lookup during request verification
- Extracted shared `authenticateJWT` helper to deduplicate JWT validation between `Authenticate` and `Middleware`
- Pins Polymarket SDK reference versions (`clob-client@v5.8.2`, `py-clob-client@v0.34.6`) and documents the SDK verification rule in `CLAUDE.md`

## Known Polymarket SDK incompatibilities — tracked in #50

SDK verification (against pinned `clob-client@v5.8.2` / `py-clob-client@v0.34.6`) surfaced five incompatibilities on the derive endpoint + HMAC signing format. A real `clob-client` request **cannot currently authenticate end-to-end** — it fails at the derive step before ever reaching this middleware.

This PR was scoped to middleware + passphrase support; the full SDK-compat fix (derive endpoint HTTP method, L1 header flow, response field names, HMAC base64url encoding) is tracked in #50 and must land before we can claim SDK compatibility.

What **does** work as shipped:
- JWT auth for our own frontend/backend
- HMAC middleware internally consistent with our own derive handler
- API key derivation + storage + revocation
- Passphrase generation, storage, and verification

## Test Plan
- [x] `TestAuthMiddleware_ValidAPIKey` — HMAC-signed request authenticates correctly
- [x] `TestAuthMiddleware_ValidJWT` — JWT bearer token fallback works
- [x] `TestAuthMiddleware_APIKeyTakesPrecedence` — API key auth used when both headers present
- [x] `TestAuthMiddleware_MissingCredentials` — 401 for no credentials
- [x] `TestAuthMiddleware_TimestampDrift` — >5s drift rejected
- [x] `TestAuthMiddleware_InvalidHMAC` — bad signature rejected
- [x] `TestAuthMiddleware_RevokedKey` — revoked key returns 401
- [x] `TestAuthMiddleware_MissingPassphrase` — request without `POLY_PASSPHRASE` rejected
- [x] `TestAuthMiddleware_WrongPassphrase` — wrong passphrase rejected
- [x] `TestDeriveAPIKey_*` updated for 3-value return (key, secret, passphrase) and deterministic passphrase derivation
- [x] `go vet`, `go build ./...` clean

Closes #38
