### PR TITLE
Tooling: quick-task agent on opus + workflow hardening

### DIFF
--- a/.claude/agents/quick-task.md
+++ b/.claude/agents/quick-task.md
@@ -1,27 +1,17 @@
 ---
 name: quick-task
-description: Execute a task independently — creates a GitHub issue, gets approval, implements, and opens a PR in its own worktree.
-model: sonnet
+description: Execute a task independently — creates a GitHub issue, gets approval, implements, verifies, and opens a PR in its own worktree.
+model: opus
 permissionMode: acceptEdits
-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
 # Task Agent
 
-You execute tasks independently in the Shisa-Fosho/services repository. You run in your own git worktree so the user's main working directory is unaffected.
+You execute tasks independently in the Shisa-Fosho/services repository. The harness runs you inside an isolated git worktree checked out from the latest `origin/main` — you do NOT need to create a worktree yourself, and you must NOT run `git checkout main`, `git reset --hard`, or switch branches. Start your work by creating a feature branch directly with `git checkout -b <new-branch-name>`.
 
 ## Before you start
 
-1. Read `CLAUDE.md` in the repo root for project conventions. Follow them exactly.
-2. Create a worktree so your changes don't affect the user's main working directory:
-
-```bash
-WORKTREE_DIR=$(mktemp -d)
-git worktree add "$WORKTREE_DIR" main
-cd "$WORKTREE_DIR"
-```
-
-All subsequent work happens in this worktree directory.
+Read `CLAUDE.md` in the repo root for project conventions. Follow them exactly.
 
 ## Workflow
 
@@ -50,6 +40,7 @@ gh project item-add 2 --owner Shisa-Fosho --url https://github.com/Shisa-Fosho/s
 ### 4. Present plan for approval
 
 Show the user:
+
 - Issue URL
 - What you plan to implement (bullet points)
 - Files you expect to touch
@@ -59,22 +50,31 @@ Show the user:
 
 ### 5. Create a branch and implement
 
-From within the worktree:
-
 ```bash
 git checkout -b {issue_number}-{short-kebab-description}
 ```
 
-- Follow conventions from CLAUDE.md and docs/conventions.md
-- Run `make lint && go build ./...` after changes (if Go code)
-- Run relevant tests
+- Follow conventions from `CLAUDE.md` and `docs/conventions.md`
+- Run `make lint && go build ./internal/...` after changes (if Go code)
+- Run relevant tests — `go test ./internal/...`
 
-### 6. Commit, push, and open PR
+### 6. Mandatory verification (BEFORE pushing)
+
+After implementing the work and BEFORE pushing or opening a PR:
+
+1. Run `git diff origin/main...HEAD --stat` to see the actual files changed
+2. Compare against the plan you proposed — every claimed file change must appear in the diff
+3. If any claimed change is MISSING from the diff (e.g. you said you deleted a file but `git status` shows it still exists), STOP and report the discrepancy — do not push
+
+If verification fails, your final message MUST say so explicitly. Do not summarize work as "done" if the diff doesn't match the plan.
+
+### 7. Commit, push, and open PR
 
 1. Stage relevant files (never stage secrets, binaries, or generated code)
-2. Commit with a clear message (no AI attribution)
+2. Commit with a clear message — **no AI attribution** (`Co-Authored-By: Claude`, 🤖 emojis, etc.)
 3. Push: `git push -u origin {branch_name}`
 4. Create PR:
+
    ```bash
    gh pr create --repo Shisa-Fosho/services \
      --title "{issue title}" \
@@ -83,20 +83,26 @@ git checkout -b {issue_number}-{short-kebab-description}
    ## Summary
    {bullet points of what changed}
 
+   ## Verified diff stat
+   \`\`\`
+   {paste of git diff --stat output}
+   \`\`\`
+
    ## Test Plan
    {how to verify}"
    ```
 
-### 7. Clean up and report
+### 8. Post-push verification
 
-Remove the worktree:
+5. Run `gh pr diff <PR#> --repo Shisa-Fosho/services | head -200` to confirm GitHub shows the same diff you committed locally
+6. Run `gh pr view <PR#> --json baseRefOid,headRefOid` and confirm `baseRefOid` matches the current `origin/main` SHA
 
-```bash
-cd /
-git -C <original_repo_path> worktree remove "$WORKTREE_DIR"
-```
+### 9. Final report
 
-Return:
+Return a message containing:
+
 - Issue URL
 - PR URL
-- Summary of what was implemented
+- Branch name
+- A copy of the `git diff --stat` output proving the changes are real
+- Verification result (all passed, or which step failed and why)

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -76,7 +76,13 @@
       "Bash(find:*)",
       "Bash(golangci-lint run:*)",
       "Bash(goimports:*)",
-      "Bash(gh search:*)"
+      "Bash(gh search:*)",
+      "WebFetch(domain:www.alexedwards.net)",
+      "Bash(cmd *)",
+      "Read(//c/Users/darre/.claude/**)",
+      "Read(//c/Users/darre/**)",
+      "Bash(python *)",
+      "Bash(claude mcp *)"
     ]
   },
   "outputStyle": "Learning"

--- a/.claude/skills/align-planning/SKILL.md
+++ b/.claude/skills/align-planning/SKILL.md
@@ -9,6 +9,7 @@ user_invocable: true
 Audits all planning sources for consistency and fixes any drift. Run this after any change to the backlog — new issues, reordering, scope changes, architectural decisions, or issue updates.
 
 **Invoke when:**
+
 - After creating or updating GitHub issues
 - After changing the project board (build order, phase, status)
 - After making architectural changes that affect service responsibilities
@@ -18,31 +19,35 @@ Audits all planning sources for consistency and fixes any drift. Run this after 
 
 ## Sources of Truth
 
-| Source | What it contains | ID / Location |
-|--------|-----------------|---------------|
-| **GitHub Issues** | Issue titles, descriptions, scope, dependencies, labels, state | `gh issue list --repo Shisa-Fosho/services` |
-| **GitHub Project Board** | Build Order numbers, Phase assignments, Status | Project #2, org Shisa-Fosho |
-| **Notion Build Order** | Issue Key table, Blocking Dependencies table, dependency graphs | `33092032f61981b6b762de2bab90eaf8` |
-| **Notion Technical Plan** | Architecture, service responsibilities, component ownership, MVP scope | `32b92032f619811aa868f4d75f5017c8` |
+| Source                    | What it contains                                                       | ID / Location                               |
+| ------------------------- | ---------------------------------------------------------------------- | ------------------------------------------- |
+| **GitHub Issues**         | Issue titles, descriptions, scope, dependencies, labels, state         | `gh issue list --repo Shisa-Fosho/services` |
+| **GitHub Project Board**  | Build Order numbers, Phase assignments, Status                         | Project #2, org Shisa-Fosho                 |
+| **Notion Build Order**    | Issue Key table, Blocking Dependencies table, dependency graphs        | `33092032f61981b6b762de2bab90eaf8`          |
+| **Notion Technical Plan** | Architecture, service responsibilities, component ownership, MVP scope | `32b92032f619811aa868f4d75f5017c8`          |
 
 ## Step 1: Gather Current State (in parallel)
 
 ### 1a. GitHub Issues
+
 ```bash
 gh issue list --repo Shisa-Fosho/services --state all --limit 100 --json number,title,state,labels,body
 ```
 
 ### 1b. GitHub Project Board
+
 ```
 gh api graphql -f query='{ organization(login: "Shisa-Fosho") { projectV2(number: 2) { items(first: 50) { nodes { bo: fieldValueByName(name: "Build Order") { ... on ProjectV2ItemFieldNumberValue { number } } phase: fieldValueByName(name: "Phase") { ... on ProjectV2ItemFieldSingleSelectValue { name } } status: fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } } content { ... on Issue { title number } ... on DraftIssue { title } } } } } } }'
 ```
 
 ### 1c. Notion Build Order doc
+
 ```
 notion-fetch: 33092032f61981b6b762de2bab90eaf8
 ```
 
 ### 1d. Notion Technical Plan
+
 ```
 notion-fetch: 32b92032f619811aa868f4d75f5017c8
 ```
@@ -52,16 +57,21 @@ notion-fetch: 32b92032f619811aa868f4d75f5017c8
 Run each check and collect findings. Do NOT fix anything yet — gather all findings first.
 
 ### 2a. Title Consistency
+
 For each item in the Notion Issue Key table, check that the corresponding GitHub issue title matches. Flag mismatches.
 
 ### 2b. Build Order Consistency
+
 Compare the ordering in the Notion Issue Key table against the GitHub project board Build Order numbers. Flag items that appear in a different sequence.
 
 ### 2c. Phase Consistency
+
 Compare the Phase column in Notion vs the Phase field on the GitHub project board. Flag mismatches.
 
 ### 2d. Dependency Consistency
+
 For each item in the Notion Blocking Dependencies table:
+
 1. Check that every "blocked-by" reference is bidirectional — if A is blocked by B, then B's "blocks" column should list A.
 2. Check that blocked-by items have a lower or equal build order number on the project board.
 3. Check that blocks items have a higher build order number.
@@ -69,22 +79,26 @@ For each item in the Notion Blocking Dependencies table:
 5. Flag any circular dependencies.
 
 ### 2e. Scope / Architecture Consistency
+
 Check the Notion Technical Plan's service responsibility assignments against what the code actually does:
-- Which service owns which endpoints (check nginx.conf routing + cmd/*/main.go wiring)
+
+- Which service owns which endpoints (check nginx.conf routing + cmd/\*/main.go wiring)
 - Which components are listed under which service in the Tech Plan
 - Flag any component listed in the wrong service
 
 ### 2f. Coverage Check
+
 1. Every item in the Notion Build Order should have a corresponding GitHub issue.
 2. Every GitHub issue with a build-order ID (S1, T3a, P2.1, SEC1, etc.) should appear in the Notion Build Order.
 3. MVP scope items in the Technical Plan should be tracked by at least one GitHub issue.
 4. Flag any items on the project board that are missing from Notion, or vice versa.
 
 ### 2g. Status Consistency
+
 - GitHub issues marked as CLOSED should have status "Done" on the project board.
 - Items with status "In Progress" on the board should have an open GitHub issue.
 
-## Step 3: Present Findings
+## Step 3: Present Findings For Approval and Iterate With User if Needed
 
 Present all findings in a table:
 
@@ -101,13 +115,14 @@ Present all findings in a table:
 ```
 
 Severity levels:
+
 - **High:** Contradictory information that could cause wrong work (e.g., component in wrong service)
 - **Medium:** Stale data that could confuse (e.g., title mismatch, dependency mismatch)
 - **Low:** Minor cosmetic drift (e.g., slightly different wording)
 
 If there are no findings, confirm alignment is clean and skip to Step 5.
 
-## Step 4: Fix Drift
+## Step 4: Once User approves Fix Drift
 
 For each finding, fix it in the source that's stale. The priority order for "which source is correct" is:
 
@@ -119,16 +134,19 @@ For each finding, fix it in the source that's stale. The priority order for "whi
 Apply fixes:
 
 ### Notion Build Order updates
+
 ```
 notion-update-page: 33092032f61981b6b762de2bab90eaf8
 ```
 
 ### Notion Technical Plan updates
+
 ```
 notion-update-page: 32b92032f619811aa868f4d75f5017c8
 ```
 
 ### GitHub Project Board updates
+
 ```bash
 # Phase
 gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id <item_id> --field-id PVTSSF_lADOEC3v5M4BUX8izhBgiKE --single-select-option-id <phase_option_id>
@@ -141,11 +159,13 @@ gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id <item_id> --field-id
 ```
 
 ### GitHub Issue updates (if needed)
+
 ```bash
 gh issue edit <number> --repo Shisa-Fosho/services --title "<title>" --body "<body>"
 ```
 
 **Phase option IDs:**
+
 - `ff13e535` — Phase 0: Foundation
 - `a9afd19d` — Phase 1: Domain Types
 - `5e1a5684` — Phase 2: First Flow
@@ -155,11 +175,13 @@ gh issue edit <number> --repo Shisa-Fosho/services --title "<title>" --body "<bo
 - `ebeb2cff` — Phase 6: Pre-Launch
 
 **Status option IDs:**
+
 - `f75ad846` — Todo
 - `47fc9ee4` — In Progress
 - `98236657` — Done
 
 **Project field IDs:**
+
 - Project: `PVT_kwDOEC3v5M4BUX8i`
 - Status: `PVTSSF_lADOEC3v5M4BUX8izhBgiFs`
 - Phase: `PVTSSF_lADOEC3v5M4BUX8izhBgiKE`

--- a/.claude/skills/quick-task/SKILL.md
+++ b/.claude/skills/quick-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick-task
-description: Dispatch a task to an independent agent in a new terminal. Usage: /quick-task "Add nginx reverse proxy"
+description: Dispatch a task to the quick-task agent in the background, in an isolated git worktree. Usage: /quick-task "Add nginx reverse proxy"
 user_invocable: true
 arguments:
   - name: task
@@ -10,12 +10,16 @@ arguments:
 
 # Quick Task Launcher
 
-Launch the quick-task agent in a new terminal window. Run this command:
+Dispatch the task to the quick-task agent using the `Agent` tool with ALL of the following parameters set:
 
-```bash
-start "" bash -c "claude --dangerously-skip-permissions --agent quick-task \"$ARGUMENTS\""
-```
+- `subagent_type: "quick-task"`
+- `run_in_background: true`
+- `isolation: "worktree"` — CRITICAL: prevents the agent from mutating the user's local branch, index, or working directory
+- `description`: a 3-5 word summary of `$ARGUMENTS`
+- `prompt`: pass `$ARGUMENTS` verbatim — the agent's behavioral instructions (workflow, verification, reporting) live in `.claude/agents/quick-task.md`, not here
 
-Tell the user: "Dispatched to a new terminal. The agent will create an issue, ask for your approval, implement, and open a PR. Switch to that terminal to interact with it."
+## After dispatching
 
-Do nothing else. Do not implement the task yourself.
+Tell the user: "Dispatched to the quick-task agent in the background, in an isolated worktree. You'll get a notification when it completes. Continue working — your local branch is untouched."
+
+Do nothing else. Do not implement the task yourself. Do not poll the agent — wait for the completion notification.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,9 @@ docs/                       # Documentation
 
 **IMPORTANT: Always read `docs/conventions.md` before writing or reviewing code.** It is the authoritative style guide.
 
+### No Speculative Code
+Only write code that is called within the current issue's scope. Do not ship unused functions, helpers, or "placeholder" code for future issues. If the next issue needs something, it will be built then — Go's compiler will catch missing functions immediately. Document any expected prerequisites in the issue description instead.
+
 ### Idempotency
 All write operations MUST be idempotent. Key source depends on operation:
 - Orders: EIP-712 signature hash (cryptographic, natural key)
@@ -329,4 +332,3 @@ ABIs consumed from the `contracts` repo via copy. No import dependency.
 | NATS | 8222 | NATS monitoring |
 | Prometheus | 9090 | Metrics collection |
 | Grafana | 3000 | Dashboards |
-| Anvil | 8545 | Local Polygon fork |


### PR DESCRIPTION
## Summary

Tooling/docs-only changes. No service code touched.

- **`.claude/agents/quick-task.md`** — bump model `sonnet` → `opus`. Drop the manual `git worktree add` setup (the harness handles isolation via `isolation: \"worktree\"`). Add a mandatory **pre-push diff verification** step (compare actual `git diff` against the proposed plan) and a **post-push PR diff confirmation** step (verify GitHub shows the same diff committed locally and that `baseRefOid` matches `origin/main`).
- **`.claude/skills/quick-task/SKILL.md`** — replace the \"open a new terminal\" launcher with an in-process Agent dispatch (`run_in_background: true`, `isolation: \"worktree\"`).
- **`CLAUDE.md`** — add a \"No Speculative Code\" rule under Key Conventions: only ship code that's called within the current issue's scope.
- **`.claude/skills/align-planning/SKILL.md`** — reformat (markdown spacing, table alignment) and split Step 3/4 into explicit approval-gated phases (\"Present Findings For Approval\" → \"Once User approves Fix Drift\").
- **`.claude/settings.local.json`** — expand local permissions (additional `Read`, `Bash` patterns, `WebFetch` domain).

## Test Plan

- [ ] Trigger a `/quick-task` invocation and confirm the dispatched agent runs in an isolated worktree without touching the parent's working tree
- [ ] Confirm the agent now uses opus (visible in the agent dispatch output)
- [ ] Verify the new pre-push verification step actually catches a planted discrepancy (e.g., a claimed change missing from the diff)