### PR TITLE
Rename short identifiers to descriptive names (closes #61)

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -21,7 +21,11 @@
 ### Naming
 - MixedCaps/camelCase (never underscores in Go identifiers)
 - Interface names: method name + "er" suffix for single-method interfaces (e.g., `Reader`, `Matcher`)
-- Receiver names: short, 1-2 chars, consistent within type (e.g., `s` for Server, `r` for Repository, `e` for Engine)
+- **All names (variables, parameters, receivers, struct fields, locals — anything that needs a name) must use full or, at worst, partial words that convey meaning.** Single-letter and 1-2 char abbreviations are prohibited. Examples:
+  - Receivers: `server` (not `s`), `repo` (not `r`), `engine` (not `e`), `handler` (not `h`), `book` (not `b`)
+  - Locals: `user` (not `u`), `order` (not `o`), `err` is allowed (idiomatic Go), `ctx` is allowed (idiomatic Go)
+  - Loop variables: `idx`/`index` (not `i`), `item` (not `v`) — even short loops should be readable
+  - The only exceptions are the universally idiomatic Go names: `ctx` (context.Context), `err` (error), `tx` (transaction), `ok` (bool from comma-ok idiom), `w`/`r` ONLY when they are `http.ResponseWriter` / `*http.Request` in a handler signature (standard library idiom)
 - Package names: short, lowercase, no underscores, no plural (e.g., `market`, `trading`, `settlement`)
 
 ### Error Handling

--- a/internal/platform/affiliate/pg_repository.go
+++ b/internal/platform/affiliate/pg_repository.go
@@ -23,11 +23,11 @@ func NewPGRepository(pool *pgxpool.Pool) *PGRepository {
 // CreateReferral persists a new referral. Validates input via ValidateReferral
 // before persisting. Also checks for circular referrals (B→A already exists
 // when inserting A→B) inside the same transaction.
-func (r *PGRepository) CreateReferral(ctx context.Context, ref *Referral) error {
+func (repo *PGRepository) CreateReferral(ctx context.Context, ref *Referral) error {
 	if err := ValidateReferral(ref); err != nil {
 		return fmt.Errorf("creating referral: %w", err)
 	}
-	tx, err := r.pool.Begin(ctx)
+	tx, err := repo.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("creating referral: beginning transaction: %w", err)
 	}
@@ -72,11 +72,11 @@ func (r *PGRepository) CreateReferral(ctx context.Context, ref *Referral) error 
 // RecordEarning persists a new affiliate earning. Validates input via
 // ValidateEarning before persisting. Returns ErrDuplicateEarning if the trade
 // ID already exists.
-func (r *PGRepository) RecordEarning(ctx context.Context, earning *Earning) error {
+func (repo *PGRepository) RecordEarning(ctx context.Context, earning *Earning) error {
 	if err := ValidateEarning(earning); err != nil {
 		return fmt.Errorf("recording earning: %w", err)
 	}
-	_, err := r.pool.Exec(ctx,
+	_, err := repo.pool.Exec(ctx,
 		`INSERT INTO affiliate_earnings (referrer_address, trade_id, fee_amount, referrer_cut)
 		 VALUES ($1, $2, $3, $4)`,
 		earning.ReferrerAddress, earning.TradeID,
@@ -93,8 +93,8 @@ func (r *PGRepository) RecordEarning(ctx context.Context, earning *Earning) erro
 }
 
 // GetEarningsByReferrer returns all earnings for a referrer.
-func (r *PGRepository) GetEarningsByReferrer(ctx context.Context, referrerAddress string) ([]*Earning, error) {
-	rows, err := r.pool.Query(ctx,
+func (repo *PGRepository) GetEarningsByReferrer(ctx context.Context, referrerAddress string) ([]*Earning, error) {
+	rows, err := repo.pool.Query(ctx,
 		`SELECT * FROM affiliate_earnings WHERE referrer_address = $1 ORDER BY created_at DESC`,
 		referrerAddress,
 	)
@@ -110,9 +110,9 @@ func (r *PGRepository) GetEarningsByReferrer(ctx context.Context, referrerAddres
 
 // GetClaimableBalance returns the aggregate claimable balance for a referrer.
 // Returns a zero-value balance if no earnings exist.
-func (r *PGRepository) GetClaimableBalance(ctx context.Context, referrerAddress string) (*ClaimableBalance, error) {
+func (repo *PGRepository) GetClaimableBalance(ctx context.Context, referrerAddress string) (*ClaimableBalance, error) {
 	var total int64
-	err := r.pool.QueryRow(ctx,
+	err := repo.pool.QueryRow(ctx,
 		`SELECT COALESCE(SUM(referrer_cut), 0) FROM affiliate_earnings
 		 WHERE referrer_address = $1`, referrerAddress,
 	).Scan(&total)

--- a/internal/platform/affiliate/validate_test.go
+++ b/internal/platform/affiliate/validate_test.go
@@ -10,49 +10,49 @@ func TestValidateReferral(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		modify  func(r *Referral)
+		modify  func(ref *Referral)
 		wantErr bool
 		errType error
 	}{
 		{
 			name:    "valid referral",
-			modify:  func(r *Referral) {},
+			modify:  func(ref *Referral) {},
 			wantErr: false,
 		},
 		{
 			name:    "empty referrer address",
-			modify:  func(r *Referral) { r.ReferrerAddress = "" },
+			modify:  func(ref *Referral) { ref.ReferrerAddress = "" },
 			wantErr: true,
 			errType: ErrInvalidReferral,
 		},
 		{
 			name:    "invalid referrer address format",
-			modify:  func(r *Referral) { r.ReferrerAddress = "not-an-address" },
+			modify:  func(ref *Referral) { ref.ReferrerAddress = "not-an-address" },
 			wantErr: true,
 			errType: ErrInvalidReferral,
 		},
 		{
 			name:    "referrer address too short",
-			modify:  func(r *Referral) { r.ReferrerAddress = "0x1234" },
+			modify:  func(ref *Referral) { ref.ReferrerAddress = "0x1234" },
 			wantErr: true,
 			errType: ErrInvalidReferral,
 		},
 		{
 			name:    "empty referred address",
-			modify:  func(r *Referral) { r.ReferredAddress = "" },
+			modify:  func(ref *Referral) { ref.ReferredAddress = "" },
 			wantErr: true,
 			errType: ErrInvalidReferral,
 		},
 		{
 			name:    "invalid referred address format",
-			modify:  func(r *Referral) { r.ReferredAddress = "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" },
+			modify:  func(ref *Referral) { ref.ReferredAddress = "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" },
 			wantErr: true,
 			errType: ErrInvalidReferral,
 		},
 		{
 			name: "self referral",
-			modify: func(r *Referral) {
-				r.ReferredAddress = r.ReferrerAddress
+			modify: func(ref *Referral) {
+				ref.ReferredAddress = ref.ReferrerAddress
 			},
 			wantErr: true,
 			errType: ErrSelfReferral,
@@ -95,47 +95,47 @@ func TestValidateEarning(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		modify  func(e *Earning)
+		modify  func(earning *Earning)
 		wantErr bool
 	}{
 		{
 			name:    "valid earning passes",
-			modify:  func(e *Earning) {},
+			modify:  func(earning *Earning) {},
 			wantErr: false,
 		},
 		{
 			name:    "empty referrer address",
-			modify:  func(e *Earning) { e.ReferrerAddress = "" },
+			modify:  func(earning *Earning) { earning.ReferrerAddress = "" },
 			wantErr: true,
 		},
 		{
 			name:    "malformed referrer address",
-			modify:  func(e *Earning) { e.ReferrerAddress = "not-an-address" },
+			modify:  func(earning *Earning) { earning.ReferrerAddress = "not-an-address" },
 			wantErr: true,
 		},
 		{
 			name:    "empty trade id",
-			modify:  func(e *Earning) { e.TradeID = "" },
+			modify:  func(earning *Earning) { earning.TradeID = "" },
 			wantErr: true,
 		},
 		{
 			name:    "zero fee amount",
-			modify:  func(e *Earning) { e.FeeAmount = 0 },
+			modify:  func(earning *Earning) { earning.FeeAmount = 0 },
 			wantErr: true,
 		},
 		{
 			name:    "negative fee amount",
-			modify:  func(e *Earning) { e.FeeAmount = -1 },
+			modify:  func(earning *Earning) { earning.FeeAmount = -1 },
 			wantErr: true,
 		},
 		{
 			name:    "zero referrer cut",
-			modify:  func(e *Earning) { e.ReferrerCut = 0 },
+			modify:  func(earning *Earning) { earning.ReferrerCut = 0 },
 			wantErr: true,
 		},
 		{
 			name:    "negative referrer cut",
-			modify:  func(e *Earning) { e.ReferrerCut = -1 },
+			modify:  func(earning *Earning) { earning.ReferrerCut = -1 },
 			wantErr: true,
 		},
 	}
@@ -143,9 +143,9 @@ func TestValidateEarning(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			e := validEarning()
-			tt.modify(e)
-			err := ValidateEarning(e)
+			earning := validEarning()
+			tt.modify(earning)
+			err := ValidateEarning(earning)
 			if tt.wantErr && err == nil {
 				t.Error("expected error, got nil")
 			}

--- a/internal/platform/auth/handler.go
+++ b/internal/platform/auth/handler.go
@@ -41,13 +41,13 @@ type HandlerOption func(*Handler)
 // failures inside session endpoints (SIWE sig mismatch, invalid refresh
 // token). Used to drive rate-limiter lockout counters. Not invoked on shape
 // errors (missing body, malformed JSON, empty required fields).
-func WithHandlerAuthFailureHook(fn func(*http.Request)) HandlerOption {
-	return func(h *Handler) { h.onAuthFailure = fn }
+func WithHandlerAuthFailureHook(hook func(*http.Request)) HandlerOption {
+	return func(handler *Handler) { handler.onAuthFailure = hook }
 }
 
 // NewHandler creates a new session handler.
 func NewHandler(logger *zap.Logger, repo data.SessionRepository, jwt *JWTManager, siwe MessageVerifier, safeCfg eth.SafeConfig, secure bool, opts ...HandlerOption) *Handler {
-	h := &Handler{
+	handler := &Handler{
 		logger:  logger,
 		repo:    repo,
 		jwt:     jwt,
@@ -55,35 +55,35 @@ func NewHandler(logger *zap.Logger, repo data.SessionRepository, jwt *JWTManager
 		safeCfg: safeCfg,
 		secure:  secure,
 	}
-	for _, fn := range opts {
-		fn(h)
+	for _, option := range opts {
+		option(handler)
 	}
-	return h
+	return handler
 }
 
 // RegisterRoutes registers session-auth routes on the mux. If authWrapper is
 // non-nil, it is applied to the credential-verify routes (signup, login,
 // refresh) — use it to inject a strict rate-limit profile. nil disables wrapping.
-func (h *Handler) RegisterRoutes(mux *http.ServeMux, authWrapper func(http.Handler) http.Handler) {
-	mux.HandleFunc("GET /auth/nonce", h.nonce)
-	mux.Handle("POST /auth/signup/wallet", wrap(authWrapper, http.HandlerFunc(h.signupWallet)))
-	mux.Handle("POST /auth/login/wallet", wrap(authWrapper, http.HandlerFunc(h.loginWallet)))
-	mux.Handle("POST /auth/refresh", wrap(authWrapper, http.HandlerFunc(h.refresh)))
-	mux.HandleFunc("POST /auth/logout", h.logout)
-	mux.Handle("GET /auth/session", Authenticate(h.jwt)(http.HandlerFunc(h.session)))
+func (handler *Handler) RegisterRoutes(mux *http.ServeMux, authWrapper func(http.Handler) http.Handler) {
+	mux.HandleFunc("GET /auth/nonce", handler.nonce)
+	mux.Handle("POST /auth/signup/wallet", wrap(authWrapper, http.HandlerFunc(handler.signupWallet)))
+	mux.Handle("POST /auth/login/wallet", wrap(authWrapper, http.HandlerFunc(handler.loginWallet)))
+	mux.Handle("POST /auth/refresh", wrap(authWrapper, http.HandlerFunc(handler.refresh)))
+	mux.HandleFunc("POST /auth/logout", handler.logout)
+	mux.Handle("GET /auth/session", Authenticate(handler.jwt)(http.HandlerFunc(handler.session)))
 }
 
-// wrap applies mw to h if mw is non-nil, otherwise returns h unchanged.
-func wrap(mw func(http.Handler) http.Handler, h http.Handler) http.Handler {
+// wrap applies mw to next if mw is non-nil, otherwise returns next unchanged.
+func wrap(mw func(http.Handler) http.Handler, next http.Handler) http.Handler {
 	if mw == nil {
-		return h
+		return next
 	}
-	return mw(h)
+	return mw(next)
 }
 
-func (h *Handler) recordAuthFailure(r *http.Request) {
-	if h.onAuthFailure != nil {
-		h.onAuthFailure(r)
+func (handler *Handler) recordAuthFailure(r *http.Request) {
+	if handler.onAuthFailure != nil {
+		handler.onAuthFailure(r)
 	}
 }
 
@@ -91,7 +91,7 @@ type nonceResponse struct {
 	Nonce string `json:"nonce"`
 }
 
-func (h *Handler) nonce(w http.ResponseWriter, _ *http.Request) {
+func (handler *Handler) nonce(w http.ResponseWriter, _ *http.Request) {
 	_ = httputil.EncodeJSON(w, http.StatusOK, nonceResponse{Nonce: GenerateNonce()})
 }
 
@@ -107,7 +107,7 @@ type authResponse struct {
 	SafeAddress string `json:"safe_address"`
 }
 
-func (h *Handler) signupWallet(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) signupWallet(w http.ResponseWriter, r *http.Request) {
 	var req walletSignupRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -118,15 +118,15 @@ func (h *Handler) signupWallet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	address, err := h.siwe.Verify(req.Message, req.Signature)
+	address, err := handler.siwe.Verify(req.Message, req.Signature)
 	if err != nil {
-		h.logger.Info("SIWE verification failed", zap.Error(err))
-		h.recordAuthFailure(r)
+		handler.logger.Info("SIWE verification failed", zap.Error(err))
+		handler.recordAuthFailure(r)
 		httputil.ErrorResponse(w, http.StatusUnauthorized, "signature verification failed")
 		return
 	}
 
-	safeAddr := eth.DeriveSafeAddress(h.safeCfg, common.HexToAddress(address))
+	safeAddr := eth.DeriveSafeAddress(handler.safeCfg, common.HexToAddress(address))
 
 	user := &data.User{
 		Address:      address,
@@ -134,7 +134,7 @@ func (h *Handler) signupWallet(w http.ResponseWriter, r *http.Request) {
 		SignupMethod: data.SignupMethodWallet,
 		SafeAddress:  safeAddr.Hex(),
 	}
-	if err := h.repo.CreateUser(r.Context(), user); err != nil {
+	if err := handler.repo.CreateUser(r.Context(), user); err != nil {
 		if errors.Is(err, data.ErrDuplicateUser) {
 			httputil.ErrorResponse(w, http.StatusConflict, "user already exists")
 			return
@@ -143,11 +143,11 @@ func (h *Handler) signupWallet(w http.ResponseWriter, r *http.Request) {
 			httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		h.internalError(w, "creating user", err)
+		handler.internalError(w, "creating user", err)
 		return
 	}
 
-	h.issueSession(w, r, address, safeAddr.Hex())
+	handler.issueSession(w, r, address, safeAddr.Hex())
 }
 
 type walletLoginRequest struct {
@@ -155,7 +155,7 @@ type walletLoginRequest struct {
 	Signature string `json:"signature"`
 }
 
-func (h *Handler) loginWallet(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) loginWallet(w http.ResponseWriter, r *http.Request) {
 	var req walletLoginRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -166,92 +166,92 @@ func (h *Handler) loginWallet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	address, err := h.siwe.Verify(req.Message, req.Signature)
+	address, err := handler.siwe.Verify(req.Message, req.Signature)
 	if err != nil {
-		h.logger.Info("SIWE verification failed", zap.Error(err))
-		h.recordAuthFailure(r)
+		handler.logger.Info("SIWE verification failed", zap.Error(err))
+		handler.recordAuthFailure(r)
 		httputil.ErrorResponse(w, http.StatusUnauthorized, "signature verification failed")
 		return
 	}
 
-	user, err := h.repo.GetUserByAddress(r.Context(), address)
+	user, err := handler.repo.GetUserByAddress(r.Context(), address)
 	if err != nil {
 		if errors.Is(err, data.ErrNotFound) {
-			h.recordAuthFailure(r)
+			handler.recordAuthFailure(r)
 			httputil.ErrorResponse(w, http.StatusUnauthorized, "user not found")
 			return
 		}
-		h.internalError(w, "getting user", err)
+		handler.internalError(w, "getting user", err)
 		return
 	}
 
-	h.issueSession(w, r, user.Address, user.SafeAddress)
+	handler.issueSession(w, r, user.Address, user.SafeAddress)
 }
 
-func (h *Handler) refresh(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) refresh(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(refreshCookieName)
 	if err != nil {
 		httputil.ErrorResponse(w, http.StatusUnauthorized, "missing refresh token")
 		return
 	}
 
-	claims, err := h.jwt.ValidateRefreshToken(cookie.Value)
+	claims, err := handler.jwt.ValidateRefreshToken(cookie.Value)
 	if err != nil {
-		h.recordAuthFailure(r)
+		handler.recordAuthFailure(r)
 		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid refresh token")
 		return
 	}
 
-	stored, err := h.repo.GetRefreshToken(r.Context(), claims.ID)
+	stored, err := handler.repo.GetRefreshToken(r.Context(), claims.ID)
 	if err != nil {
-		h.recordAuthFailure(r)
+		handler.recordAuthFailure(r)
 		httputil.ErrorResponse(w, http.StatusUnauthorized, "invalid refresh token")
 		return
 	}
 	if stored.Revoked {
-		h.recordAuthFailure(r)
+		handler.recordAuthFailure(r)
 		httputil.ErrorResponse(w, http.StatusUnauthorized, "token revoked")
 		return
 	}
 
-	if err := h.repo.RevokeRefreshToken(r.Context(), claims.ID); err != nil {
-		h.internalError(w, "revoking old refresh token", err)
+	if err := handler.repo.RevokeRefreshToken(r.Context(), claims.ID); err != nil {
+		handler.internalError(w, "revoking old refresh token", err)
 		return
 	}
 
-	accessToken, err := h.jwt.IssueAccessToken(claims.Subject)
+	accessToken, err := handler.jwt.IssueAccessToken(claims.Subject)
 	if err != nil {
-		h.internalError(w, "issuing access token", err)
+		handler.internalError(w, "issuing access token", err)
 		return
 	}
 
-	refreshToken, jti, expiresAt, err := h.jwt.IssueRefreshToken(claims.Subject)
+	refreshToken, jti, expiresAt, err := handler.jwt.IssueRefreshToken(claims.Subject)
 	if err != nil {
-		h.internalError(w, "issuing refresh token", err)
+		handler.internalError(w, "issuing refresh token", err)
 		return
 	}
 
-	if err := h.repo.StoreRefreshToken(r.Context(), &data.RefreshToken{
+	if err := handler.repo.StoreRefreshToken(r.Context(), &data.RefreshToken{
 		ID:          jti,
 		UserAddress: claims.Subject,
 		ExpiresAt:   expiresAt,
 	}); err != nil {
-		h.internalError(w, "storing refresh token", err)
+		handler.internalError(w, "storing refresh token", err)
 		return
 	}
 
-	h.setRefreshCookie(w, refreshToken, expiresAt)
+	handler.setRefreshCookie(w, refreshToken, expiresAt)
 	_ = httputil.EncodeJSON(w, http.StatusOK, map[string]string{
 		"access_token": accessToken,
 	})
 }
 
-func (h *Handler) logout(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) logout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(refreshCookieName)
 	if err == nil && cookie.Value != "" {
-		claims, err := h.jwt.ValidateRefreshToken(cookie.Value)
+		claims, err := handler.jwt.ValidateRefreshToken(cookie.Value)
 		if err == nil {
-			_ = h.repo.RevokeRefreshToken(r.Context(), claims.ID)
+			_ = handler.repo.RevokeRefreshToken(r.Context(), claims.ID)
 		}
 	}
 
@@ -262,7 +262,7 @@ func (h *Handler) logout(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   -1,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   h.secure,
+		Secure:   handler.secure,
 	})
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -273,15 +273,15 @@ type sessionResponse struct {
 	SafeAddress string `json:"safe_address"`
 }
 
-func (h *Handler) session(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) session(w http.ResponseWriter, r *http.Request) {
 	address := UserAddressFrom(r.Context())
-	user, err := h.repo.GetUserByAddress(r.Context(), address)
+	user, err := handler.repo.GetUserByAddress(r.Context(), address)
 	if err != nil {
 		if errors.Is(err, data.ErrNotFound) {
 			httputil.ErrorResponse(w, http.StatusUnauthorized, "user not found")
 			return
 		}
-		h.internalError(w, "getting user for session", err)
+		handler.internalError(w, "getting user for session", err)
 		return
 	}
 
@@ -294,29 +294,29 @@ func (h *Handler) session(w http.ResponseWriter, r *http.Request) {
 
 // issueSession creates access + refresh tokens, stores the refresh token,
 // sets the cookie, and writes the JSON response.
-func (h *Handler) issueSession(w http.ResponseWriter, r *http.Request, address, safeAddress string) {
-	accessToken, err := h.jwt.IssueAccessToken(address)
+func (handler *Handler) issueSession(w http.ResponseWriter, r *http.Request, address, safeAddress string) {
+	accessToken, err := handler.jwt.IssueAccessToken(address)
 	if err != nil {
-		h.internalError(w, "issuing access token", err)
+		handler.internalError(w, "issuing access token", err)
 		return
 	}
 
-	refreshToken, jti, expiresAt, err := h.jwt.IssueRefreshToken(address)
+	refreshToken, jti, expiresAt, err := handler.jwt.IssueRefreshToken(address)
 	if err != nil {
-		h.internalError(w, "issuing refresh token", err)
+		handler.internalError(w, "issuing refresh token", err)
 		return
 	}
 
-	if err := h.repo.StoreRefreshToken(r.Context(), &data.RefreshToken{
+	if err := handler.repo.StoreRefreshToken(r.Context(), &data.RefreshToken{
 		ID:          jti,
 		UserAddress: address,
 		ExpiresAt:   expiresAt,
 	}); err != nil {
-		h.internalError(w, "storing refresh token", err)
+		handler.internalError(w, "storing refresh token", err)
 		return
 	}
 
-	h.setRefreshCookie(w, refreshToken, expiresAt)
+	handler.setRefreshCookie(w, refreshToken, expiresAt)
 	_ = httputil.EncodeJSON(w, http.StatusOK, authResponse{
 		AccessToken: accessToken,
 		Address:     address,
@@ -324,12 +324,12 @@ func (h *Handler) issueSession(w http.ResponseWriter, r *http.Request, address, 
 	})
 }
 
-func (h *Handler) internalError(w http.ResponseWriter, msg string, err error) {
-	h.logger.Error(msg, zap.Error(err))
+func (handler *Handler) internalError(w http.ResponseWriter, msg string, err error) {
+	handler.logger.Error(msg, zap.Error(err))
 	httputil.ErrorResponse(w, http.StatusInternalServerError, "internal server error")
 }
 
-func (h *Handler) setRefreshCookie(w http.ResponseWriter, token string, expiresAt time.Time) {
+func (handler *Handler) setRefreshCookie(w http.ResponseWriter, token string, expiresAt time.Time) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     refreshCookieName,
 		Value:    token,
@@ -337,6 +337,6 @@ func (h *Handler) setRefreshCookie(w http.ResponseWriter, token string, expiresA
 		Expires:  expiresAt,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   h.secure,
+		Secure:   handler.secure,
 	})
 }

--- a/internal/platform/auth/handler_test.go
+++ b/internal/platform/auth/handler_test.go
@@ -21,11 +21,11 @@ type fakeVerifier struct {
 	err     error
 }
 
-func (f *fakeVerifier) Verify(message, signature string) (string, error) {
-	if f.err != nil {
-		return "", f.err
+func (verifier *fakeVerifier) Verify(message, signature string) (string, error) {
+	if verifier.err != nil {
+		return "", verifier.err
 	}
-	return f.address, nil
+	return verifier.address, nil
 }
 
 // fakeRepo is an in-memory SessionRepository implementation for tests. It
@@ -43,65 +43,65 @@ func newFakeRepo() *fakeRepo {
 	}
 }
 
-func (r *fakeRepo) CreateUser(_ context.Context, user *data.User) error {
-	if _, exists := r.users[user.Address]; exists {
+func (store *fakeRepo) CreateUser(_ context.Context, user *data.User) error {
+	if _, exists := store.users[user.Address]; exists {
 		return data.ErrDuplicateUser
 	}
-	r.users[user.Address] = user
+	store.users[user.Address] = user
 	return nil
 }
 
-func (r *fakeRepo) GetUserByAddress(_ context.Context, address string) (*data.User, error) {
-	u, ok := r.users[address]
+func (store *fakeRepo) GetUserByAddress(_ context.Context, address string) (*data.User, error) {
+	user, ok := store.users[address]
 	if !ok {
 		return nil, data.ErrNotFound
 	}
-	return u, nil
+	return user, nil
 }
 
-func (r *fakeRepo) GetUserByEmail(_ context.Context, email string) (*data.User, error) {
-	for _, u := range r.users {
-		if u.Email != nil && *u.Email == email {
-			return u, nil
+func (store *fakeRepo) GetUserByEmail(_ context.Context, email string) (*data.User, error) {
+	for _, user := range store.users {
+		if user.Email != nil && *user.Email == email {
+			return user, nil
 		}
 	}
 	return nil, data.ErrNotFound
 }
 
-func (r *fakeRepo) UpsertPosition(_ context.Context, _ *data.Position) error { return nil }
-func (r *fakeRepo) GetPositionsByUser(_ context.Context, _ string) ([]*data.Position, error) {
+func (store *fakeRepo) UpsertPosition(_ context.Context, _ *data.Position) error { return nil }
+func (store *fakeRepo) GetPositionsByUser(_ context.Context, _ string) ([]*data.Position, error) {
 	return nil, nil
 }
-func (r *fakeRepo) GetPosition(_ context.Context, _ string, _ string, _ data.Side) (*data.Position, error) {
+func (store *fakeRepo) GetPosition(_ context.Context, _ string, _ string, _ data.Side) (*data.Position, error) {
 	return nil, data.ErrNotFound
 }
 
-func (r *fakeRepo) StoreRefreshToken(_ context.Context, token *data.RefreshToken) error {
-	r.refreshTokens[token.ID] = token
+func (store *fakeRepo) StoreRefreshToken(_ context.Context, token *data.RefreshToken) error {
+	store.refreshTokens[token.ID] = token
 	return nil
 }
 
-func (r *fakeRepo) GetRefreshToken(_ context.Context, id string) (*data.RefreshToken, error) {
-	t, ok := r.refreshTokens[id]
+func (store *fakeRepo) GetRefreshToken(_ context.Context, id string) (*data.RefreshToken, error) {
+	token, ok := store.refreshTokens[id]
 	if !ok {
 		return nil, data.ErrNotFound
 	}
-	return t, nil
+	return token, nil
 }
 
-func (r *fakeRepo) RevokeRefreshToken(_ context.Context, id string) error {
-	t, ok := r.refreshTokens[id]
+func (store *fakeRepo) RevokeRefreshToken(_ context.Context, id string) error {
+	token, ok := store.refreshTokens[id]
 	if !ok {
 		return data.ErrNotFound
 	}
-	t.Revoked = true
+	token.Revoked = true
 	return nil
 }
 
-func (r *fakeRepo) RevokeAllRefreshTokens(_ context.Context, userAddress string) error {
-	for _, t := range r.refreshTokens {
-		if t.UserAddress == userAddress {
-			t.Revoked = true
+func (store *fakeRepo) RevokeAllRefreshTokens(_ context.Context, userAddress string) error {
+	for _, token := range store.refreshTokens {
+		if token.UserAddress == userAddress {
+			token.Revoked = true
 		}
 	}
 	return nil
@@ -127,19 +127,19 @@ func TestSignupWallet_Success(t *testing.T) {
 	addr := "0x1234567890AbcdEF1234567890aBcdef12345678"
 	repo := newFakeRepo()
 	verifier := &fakeVerifier{address: addr}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
 	body := `{"message":"test","signature":"0xtest","username":"alice"}`
-	r := httptest.NewRequest(http.MethodPost, "/auth/signup/wallet", strings.NewReader(body))
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/signup/wallet", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
 
-	h.signupWallet(w, r)
+	handler.signupWallet(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 	var resp authResponse
-	json.NewDecoder(w.Body).Decode(&resp)
+	json.NewDecoder(recorder.Body).Decode(&resp)
 	if resp.AccessToken == "" {
 		t.Error("expected non-empty access token")
 	}
@@ -150,12 +150,12 @@ func TestSignupWallet_Success(t *testing.T) {
 		t.Error("expected non-empty safe address")
 	}
 
-	cookies := w.Result().Cookies()
+	cookies := recorder.Result().Cookies()
 	found := false
-	for _, c := range cookies {
-		if c.Name == refreshCookieName {
+	for _, cookie := range cookies {
+		if cookie.Name == refreshCookieName {
 			found = true
-			if !c.HttpOnly {
+			if !cookie.HttpOnly {
 				t.Error("refresh cookie should be HttpOnly")
 			}
 		}
@@ -172,16 +172,16 @@ func TestSignupWallet_DuplicateUser(t *testing.T) {
 	repo := newFakeRepo()
 	repo.users[addr] = &data.User{Address: addr, Username: "alice"}
 	verifier := &fakeVerifier{address: addr}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
 	body := `{"message":"test","signature":"0xtest","username":"bob"}`
-	r := httptest.NewRequest(http.MethodPost, "/auth/signup/wallet", strings.NewReader(body))
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/signup/wallet", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
 
-	h.signupWallet(w, r)
+	handler.signupWallet(recorder, request)
 
-	if w.Code != http.StatusConflict {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	if recorder.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusConflict)
 	}
 }
 
@@ -190,16 +190,16 @@ func TestSignupWallet_MissingUsername(t *testing.T) {
 
 	repo := newFakeRepo()
 	verifier := &fakeVerifier{address: "0x1111111111111111111111111111111111111111"}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
 	body := `{"message":"test","signature":"0xtest"}`
-	r := httptest.NewRequest(http.MethodPost, "/auth/signup/wallet", strings.NewReader(body))
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/signup/wallet", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
 
-	h.signupWallet(w, r)
+	handler.signupWallet(recorder, request)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
 }
 
@@ -214,16 +214,16 @@ func TestLoginWallet_Success(t *testing.T) {
 		SafeAddress: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 	}
 	verifier := &fakeVerifier{address: addr}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
 	body := `{"message":"test","signature":"0xtest"}`
-	r := httptest.NewRequest(http.MethodPost, "/auth/login/wallet", strings.NewReader(body))
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/login/wallet", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
 
-	h.loginWallet(w, r)
+	handler.loginWallet(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 }
 
@@ -232,16 +232,16 @@ func TestLoginWallet_UnknownUser(t *testing.T) {
 
 	repo := newFakeRepo()
 	verifier := &fakeVerifier{address: "0x1111111111111111111111111111111111111111"}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
 	body := `{"message":"test","signature":"0xtest"}`
-	r := httptest.NewRequest(http.MethodPost, "/auth/login/wallet", strings.NewReader(body))
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/login/wallet", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
 
-	h.loginWallet(w, r)
+	handler.loginWallet(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -260,16 +260,16 @@ func TestRefresh_Success(t *testing.T) {
 	}
 
 	verifier := &fakeVerifier{address: addr}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
-	r := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
-	r.AddCookie(&http.Cookie{Name: refreshCookieName, Value: tokenStr})
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	request.AddCookie(&http.Cookie{Name: refreshCookieName, Value: tokenStr})
+	recorder := httptest.NewRecorder()
 
-	h.refresh(w, r)
+	handler.refresh(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 	if !repo.refreshTokens[jti].Revoked {
 		t.Error("old refresh token should be revoked after rotation")
@@ -292,16 +292,16 @@ func TestRefresh_RevokedToken(t *testing.T) {
 	}
 
 	verifier := &fakeVerifier{address: addr}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
-	r := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
-	r.AddCookie(&http.Cookie{Name: refreshCookieName, Value: tokenStr})
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	request.AddCookie(&http.Cookie{Name: refreshCookieName, Value: tokenStr})
+	recorder := httptest.NewRecorder()
 
-	h.refresh(w, r)
+	handler.refresh(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -310,15 +310,15 @@ func TestRefresh_MissingCookie(t *testing.T) {
 
 	repo := newFakeRepo()
 	verifier := &fakeVerifier{}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
-	r := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	recorder := httptest.NewRecorder()
 
-	h.refresh(w, r)
+	handler.refresh(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -327,20 +327,20 @@ func TestLogout_ClearsCookie(t *testing.T) {
 
 	repo := newFakeRepo()
 	verifier := &fakeVerifier{}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
-	r := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	recorder := httptest.NewRecorder()
 
-	h.logout(w, r)
+	handler.logout(recorder, request)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusNoContent)
 	}
 
-	cookies := w.Result().Cookies()
-	for _, c := range cookies {
-		if c.Name == refreshCookieName && c.MaxAge != -1 {
+	cookies := recorder.Result().Cookies()
+	for _, cookie := range cookies {
+		if cookie.Name == refreshCookieName && cookie.MaxAge != -1 {
 			t.Error("refresh cookie should have MaxAge -1")
 		}
 	}
@@ -358,19 +358,19 @@ func TestSession_Valid(t *testing.T) {
 	}
 
 	verifier := &fakeVerifier{}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/session", nil)
-	r = r.WithContext(WithUserAddress(r.Context(), addr))
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/auth/session", nil)
+	request = request.WithContext(WithUserAddress(request.Context(), addr))
+	recorder := httptest.NewRecorder()
 
-	h.session(w, r)
+	handler.session(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 	var resp sessionResponse
-	json.NewDecoder(w.Body).Decode(&resp)
+	json.NewDecoder(recorder.Body).Decode(&resp)
 	if resp.Address != addr {
 		t.Errorf("address = %q, want %q", resp.Address, addr)
 	}
@@ -384,19 +384,19 @@ func TestSession_InvalidToken(t *testing.T) {
 
 	repo := newFakeRepo()
 	verifier := &fakeVerifier{}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
 	mux := http.NewServeMux()
-	h.RegisterRoutes(mux, nil)
+	handler.RegisterRoutes(mux, nil)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/session", nil)
-	r.Header.Set("Authorization", "Bearer invalid-token")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/auth/session", nil)
+	request.Header.Set("Authorization", "Bearer invalid-token")
+	recorder := httptest.NewRecorder()
 
-	mux.ServeHTTP(w, r)
+	mux.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -405,18 +405,18 @@ func TestNonce_ReturnsNonce(t *testing.T) {
 
 	repo := newFakeRepo()
 	verifier := &fakeVerifier{}
-	h := testHandler(t, repo, verifier)
+	handler := testHandler(t, repo, verifier)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/nonce", nil)
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/auth/nonce", nil)
+	recorder := httptest.NewRecorder()
 
-	h.nonce(w, r)
+	handler.nonce(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
 	}
 	var resp nonceResponse
-	json.NewDecoder(w.Body).Decode(&resp)
+	json.NewDecoder(recorder.Body).Decode(&resp)
 	if resp.Nonce == "" {
 		t.Error("expected non-empty nonce")
 	}

--- a/internal/platform/auth/jwt.go
+++ b/internal/platform/auth/jwt.go
@@ -73,19 +73,19 @@ func NewJWTManager(cfg JWTConfig) (*JWTManager, error) {
 }
 
 // IssueAccessToken creates a signed access token for the given address.
-func (m *JWTManager) IssueAccessToken(address string) (string, error) {
+func (manager *JWTManager) IssueAccessToken(address string) (string, error) {
 	now := time.Now()
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
-			Issuer:    m.cfg.Issuer,
+			Issuer:    manager.cfg.Issuer,
 			Subject:   address,
 			IssuedAt:  jwt.NewNumericDate(now),
-			ExpiresAt: jwt.NewNumericDate(now.Add(m.cfg.AccessTTL)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(manager.cfg.AccessTTL)),
 		},
 		Kind: TokenAccess,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signed, err := token.SignedString(m.cfg.AccessSecret)
+	signed, err := token.SignedString(manager.cfg.AccessSecret)
 	if err != nil {
 		return "", fmt.Errorf("signing access token: %w", err)
 	}
@@ -95,9 +95,9 @@ func (m *JWTManager) IssueAccessToken(address string) (string, error) {
 // IssueRefreshToken creates a signed refresh token for the given address.
 // Returns (tokenString, jti, expiresAt, error) so the caller can persist
 // the JTI for rotation tracking.
-func (m *JWTManager) IssueRefreshToken(address string) (string, string, time.Time, error) {
+func (manager *JWTManager) IssueRefreshToken(address string) (string, string, time.Time, error) {
 	now := time.Now()
-	expiresAt := now.Add(m.cfg.RefreshTTL)
+	expiresAt := now.Add(manager.cfg.RefreshTTL)
 	jti, err := randomHex(16)
 	if err != nil {
 		return "", "", time.Time{}, fmt.Errorf("generating JTI: %w", err)
@@ -106,7 +106,7 @@ func (m *JWTManager) IssueRefreshToken(address string) (string, string, time.Tim
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			ID:        jti,
-			Issuer:    m.cfg.Issuer,
+			Issuer:    manager.cfg.Issuer,
 			Subject:   address,
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
@@ -114,7 +114,7 @@ func (m *JWTManager) IssueRefreshToken(address string) (string, string, time.Tim
 		Kind: TokenRefresh,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signed, err := token.SignedString(m.cfg.RefreshSecret)
+	signed, err := token.SignedString(manager.cfg.RefreshSecret)
 	if err != nil {
 		return "", "", time.Time{}, fmt.Errorf("signing refresh token: %w", err)
 	}
@@ -123,21 +123,21 @@ func (m *JWTManager) IssueRefreshToken(address string) (string, string, time.Tim
 
 // ValidateAccessToken parses and validates an access token string.
 // Returns the Claims or an error. Rejects refresh tokens.
-func (m *JWTManager) ValidateAccessToken(tokenStr string) (*Claims, error) {
-	return m.validateToken(tokenStr, m.cfg.AccessSecret, TokenAccess)
+func (manager *JWTManager) ValidateAccessToken(tokenStr string) (*Claims, error) {
+	return manager.validateToken(tokenStr, manager.cfg.AccessSecret, TokenAccess)
 }
 
 // ValidateRefreshToken parses and validates a refresh token string.
 // Returns the Claims or an error. Rejects access tokens.
-func (m *JWTManager) ValidateRefreshToken(tokenStr string) (*Claims, error) {
-	return m.validateToken(tokenStr, m.cfg.RefreshSecret, TokenRefresh)
+func (manager *JWTManager) ValidateRefreshToken(tokenStr string) (*Claims, error) {
+	return manager.validateToken(tokenStr, manager.cfg.RefreshSecret, TokenRefresh)
 }
 
-func (m *JWTManager) validateToken(tokenStr string, secret []byte, expectedKind TokenKind) (*Claims, error) {
+func (manager *JWTManager) validateToken(tokenStr string, secret []byte, expectedKind TokenKind) (*Claims, error) {
 	claims := &Claims{}
-	token, err := jwt.ParseWithClaims(tokenStr, claims, func(t *jwt.Token) (any, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+	token, err := jwt.ParseWithClaims(tokenStr, claims, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return secret, nil
 	})
@@ -153,12 +153,12 @@ func (m *JWTManager) validateToken(tokenStr string, secret []byte, expectedKind 
 	return claims, nil
 }
 
-// randomHex generates n cryptographically random bytes and returns them
+// randomHex generates size cryptographically random bytes and returns them
 // as a hex-encoded string.
-func randomHex(n int) (string, error) {
-	b := make([]byte, n)
-	if _, err := rand.Read(b); err != nil {
+func randomHex(size int) (string, error) {
+	buf := make([]byte, size)
+	if _, err := rand.Read(buf); err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(b), nil
+	return hex.EncodeToString(buf), nil
 }

--- a/internal/platform/auth/middleware_test.go
+++ b/internal/platform/auth/middleware_test.go
@@ -20,14 +20,14 @@ func TestAuthenticate_ValidToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.Header.Set("Authorization", "Bearer "+token)
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	recorder := httptest.NewRecorder()
 
-	handler.ServeHTTP(w, r)
+	handler.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	if recorder.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusOK)
 	}
 	if gotAddr != addr {
 		t.Errorf("address = %q, want %q", gotAddr, addr)
@@ -42,13 +42,13 @@ func TestAuthenticate_MissingHeader(t *testing.T) {
 		t.Error("handler should not be called")
 	}))
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
 
-	handler.ServeHTTP(w, r)
+	handler.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -60,14 +60,14 @@ func TestAuthenticate_MalformedHeader(t *testing.T) {
 		t.Error("handler should not be called")
 	}))
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.Header.Set("Authorization", "NotBearer some-token")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Authorization", "NotBearer some-token")
+	recorder := httptest.NewRecorder()
 
-	handler.ServeHTTP(w, r)
+	handler.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -79,16 +79,16 @@ func TestAuthenticate_ExpiredToken(t *testing.T) {
 		t.Error("handler should not be called")
 	}))
 
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.Header.Set("Authorization", "Bearer expired.jwt.token")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Authorization", "Bearer expired.jwt.token")
+	recorder := httptest.NewRecorder()
 
-	handler.ServeHTTP(w, r)
+	handler.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
-	if !strings.Contains(w.Body.String(), "invalid token") {
-		t.Errorf("body = %q, want 'invalid token'", w.Body.String())
+	if !strings.Contains(recorder.Body.String(), "invalid token") {
+		t.Errorf("body = %q, want 'invalid token'", recorder.Body.String())
 	}
 }

--- a/internal/platform/auth/siwe.go
+++ b/internal/platform/auth/siwe.go
@@ -148,15 +148,15 @@ func NewSIWEVerifier(cfg SIWEConfig) *SIWEVerifier {
 
 // Verify parses a SIWE message, validates the EIP-191 personal_sign signature,
 // checks the domain and expiration, and returns the checksummed signer address.
-func (v *SIWEVerifier) Verify(message string, signature string) (string, error) {
+func (verifier *SIWEVerifier) Verify(message string, signature string) (string, error) {
 	parsed, err := ParseSIWEMessage(message)
 	if err != nil {
 		return "", fmt.Errorf("parsing SIWE message: %w", err)
 	}
 
 	// Validate domain.
-	if parsed.Domain != v.cfg.Domain {
-		return "", fmt.Errorf("domain mismatch: got %q, want %q", parsed.Domain, v.cfg.Domain)
+	if parsed.Domain != verifier.cfg.Domain {
+		return "", fmt.Errorf("domain mismatch: got %q, want %q", parsed.Domain, verifier.cfg.Domain)
 	}
 
 	// Validate expiration.

--- a/internal/platform/auth/siwe_test.go
+++ b/internal/platform/auth/siwe_test.go
@@ -38,19 +38,19 @@ func signSIWEMessage(t *testing.T, key *ecdsa.PrivateKey, message string) string
 // buildSIWEMessage constructs a valid EIP-4361 message string.
 func buildSIWEMessage(domain, address, nonce string, expiration *time.Time) string {
 	now := time.Now().UTC().Truncate(time.Second)
-	var b strings.Builder
-	fmt.Fprintf(&b, "%s wants you to sign in with your Ethereum account:\n", domain)
-	fmt.Fprintf(&b, "%s\n", address)
-	fmt.Fprintf(&b, "\nSign in to Shisa\n\n")
-	fmt.Fprintf(&b, "URI: https://%s\n", domain)
-	fmt.Fprintf(&b, "Version: 1\n")
-	fmt.Fprintf(&b, "Chain ID: 137\n")
-	fmt.Fprintf(&b, "Nonce: %s\n", nonce)
-	fmt.Fprintf(&b, "Issued At: %s", now.Format(time.RFC3339))
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "%s wants you to sign in with your Ethereum account:\n", domain)
+	fmt.Fprintf(&builder, "%s\n", address)
+	fmt.Fprintf(&builder, "\nSign in to Shisa\n\n")
+	fmt.Fprintf(&builder, "URI: https://%s\n", domain)
+	fmt.Fprintf(&builder, "Version: 1\n")
+	fmt.Fprintf(&builder, "Chain ID: 137\n")
+	fmt.Fprintf(&builder, "Nonce: %s\n", nonce)
+	fmt.Fprintf(&builder, "Issued At: %s", now.Format(time.RFC3339))
 	if expiration != nil {
-		fmt.Fprintf(&b, "\nExpiration Time: %s", expiration.Format(time.RFC3339))
+		fmt.Fprintf(&builder, "\nExpiration Time: %s", expiration.Format(time.RFC3339))
 	}
-	return b.String()
+	return builder.String()
 }
 
 func TestSIWEVerify_ValidMessage(t *testing.T) {
@@ -172,20 +172,20 @@ func TestGenerateNonce_Uniqueness(t *testing.T) {
 	t.Parallel()
 
 	seen := make(map[string]bool)
-	for i := 0; i < 100; i++ {
-		n := GenerateNonce()
-		if seen[n] {
-			t.Fatalf("duplicate nonce at iteration %d: %s", i, n)
+	for iter := 0; iter < 100; iter++ {
+		nonce := GenerateNonce()
+		if seen[nonce] {
+			t.Fatalf("duplicate nonce at iteration %d: %s", iter, nonce)
 		}
-		seen[n] = true
+		seen[nonce] = true
 	}
 }
 
 func TestGenerateNonce_Length(t *testing.T) {
 	t.Parallel()
 
-	n := GenerateNonce()
-	if len(n) != 32 { // 16 bytes = 32 hex chars
-		t.Errorf("nonce length = %d, want 32", len(n))
+	nonce := GenerateNonce()
+	if len(nonce) != 32 { // 16 bytes = 32 hex chars
+		t.Errorf("nonce length = %d, want 32", len(nonce))
 	}
 }

--- a/internal/platform/data/domain.go
+++ b/internal/platform/data/domain.go
@@ -26,8 +26,8 @@ const (
 	SignupMethodEmail  SignupMethod = 1
 )
 
-func (m SignupMethod) String() string {
-	switch m {
+func (method SignupMethod) String() string {
+	switch method {
 	case SignupMethodWallet:
 		return "WALLET"
 	case SignupMethodEmail:
@@ -38,8 +38,8 @@ func (m SignupMethod) String() string {
 }
 
 // IsValid returns true if the signup method is a known value.
-func (m SignupMethod) IsValid() bool {
-	return m == SignupMethodWallet || m == SignupMethodEmail
+func (method SignupMethod) IsValid() bool {
+	return method == SignupMethodWallet || method == SignupMethodEmail
 }
 
 // Side represents the direction of a position (BUY or SELL).
@@ -52,8 +52,8 @@ const (
 	SideSell Side = 1
 )
 
-func (s Side) String() string {
-	switch s {
+func (side Side) String() string {
+	switch side {
 	case SideBuy:
 		return "BUY"
 	case SideSell:
@@ -64,8 +64,8 @@ func (s Side) String() string {
 }
 
 // IsValid returns true if the side is BUY or SELL.
-func (s Side) IsValid() bool {
-	return s == SideBuy || s == SideSell
+func (side Side) IsValid() bool {
+	return side == SideBuy || side == SideSell
 }
 
 // User represents a registered user of the platform.

--- a/internal/platform/data/pg_repository.go
+++ b/internal/platform/data/pg_repository.go
@@ -24,11 +24,11 @@ func NewPGRepository(pool *pgxpool.Pool) *PGRepository {
 // CreateUser persists a new user. Validates input via ValidateUser before
 // persisting. Returns ErrInvalidUser for shape violations, ErrDuplicateUser
 // if the address, username, or email already exists.
-func (r *PGRepository) CreateUser(ctx context.Context, user *User) error {
+func (repo *PGRepository) CreateUser(ctx context.Context, user *User) error {
 	if err := ValidateUser(user); err != nil {
 		return fmt.Errorf("creating user: %w", err)
 	}
-	_, err := r.pool.Exec(ctx,
+	_, err := repo.pool.Exec(ctx,
 		`INSERT INTO users (
 			address, username, email, signup_method, safe_address,
 			proxy_address, twofa_secret_encrypted, twofa_enabled
@@ -47,8 +47,8 @@ func (r *PGRepository) CreateUser(ctx context.Context, user *User) error {
 }
 
 // GetUserByAddress retrieves a user by Ethereum address.
-func (r *PGRepository) GetUserByAddress(ctx context.Context, address string) (*User, error) {
-	rows, err := r.pool.Query(ctx, `SELECT * FROM users WHERE address = $1`, address)
+func (repo *PGRepository) GetUserByAddress(ctx context.Context, address string) (*User, error) {
+	rows, err := repo.pool.Query(ctx, `SELECT * FROM users WHERE address = $1`, address)
 	if err != nil {
 		return nil, fmt.Errorf("getting user %s: %w", address, err)
 	}
@@ -63,8 +63,8 @@ func (r *PGRepository) GetUserByAddress(ctx context.Context, address string) (*U
 }
 
 // GetUserByEmail retrieves a user by email address.
-func (r *PGRepository) GetUserByEmail(ctx context.Context, email string) (*User, error) {
-	rows, err := r.pool.Query(ctx, `SELECT * FROM users WHERE email = $1`, email)
+func (repo *PGRepository) GetUserByEmail(ctx context.Context, email string) (*User, error) {
+	rows, err := repo.pool.Query(ctx, `SELECT * FROM users WHERE email = $1`, email)
 	if err != nil {
 		return nil, fmt.Errorf("getting user by email: %w", err)
 	}
@@ -80,11 +80,11 @@ func (r *PGRepository) GetUserByEmail(ctx context.Context, email string) (*User,
 
 // UpsertPosition creates or updates a position for a user in a market.
 // Validates input via ValidatePosition before persisting.
-func (r *PGRepository) UpsertPosition(ctx context.Context, pos *Position) error {
+func (repo *PGRepository) UpsertPosition(ctx context.Context, pos *Position) error {
 	if err := ValidatePosition(pos); err != nil {
 		return fmt.Errorf("upserting position: %w", err)
 	}
-	_, err := r.pool.Exec(ctx,
+	_, err := repo.pool.Exec(ctx,
 		`INSERT INTO positions (user_address, market_id, side, size, average_entry_price, realised_pnl)
 		 VALUES ($1, $2, $3, $4, $5, $6)
 		 ON CONFLICT (user_address, market_id, side)
@@ -102,8 +102,8 @@ func (r *PGRepository) UpsertPosition(ctx context.Context, pos *Position) error 
 }
 
 // GetPositionsByUser returns all positions for a given user address.
-func (r *PGRepository) GetPositionsByUser(ctx context.Context, userAddress string) ([]*Position, error) {
-	rows, err := r.pool.Query(ctx,
+func (repo *PGRepository) GetPositionsByUser(ctx context.Context, userAddress string) ([]*Position, error) {
+	rows, err := repo.pool.Query(ctx,
 		`SELECT * FROM positions WHERE user_address = $1 ORDER BY market_id`,
 		userAddress,
 	)
@@ -118,8 +118,8 @@ func (r *PGRepository) GetPositionsByUser(ctx context.Context, userAddress strin
 }
 
 // GetPosition retrieves a single position by its composite key.
-func (r *PGRepository) GetPosition(ctx context.Context, userAddress string, marketID string, side Side) (*Position, error) {
-	rows, err := r.pool.Query(ctx,
+func (repo *PGRepository) GetPosition(ctx context.Context, userAddress string, marketID string, side Side) (*Position, error) {
+	rows, err := repo.pool.Query(ctx,
 		`SELECT * FROM positions WHERE user_address = $1 AND market_id = $2 AND side = $3`,
 		userAddress, marketID, side,
 	)
@@ -140,8 +140,8 @@ func (r *PGRepository) GetPosition(ctx context.Context, userAddress string, mark
 }
 
 // StoreRefreshToken persists a new refresh token.
-func (r *PGRepository) StoreRefreshToken(ctx context.Context, token *RefreshToken) error {
-	_, err := r.pool.Exec(ctx,
+func (repo *PGRepository) StoreRefreshToken(ctx context.Context, token *RefreshToken) error {
+	_, err := repo.pool.Exec(ctx,
 		`INSERT INTO refresh_tokens (id, user_address, expires_at)
 		 VALUES ($1, $2, $3)`,
 		token.ID, token.UserAddress, token.ExpiresAt,
@@ -153,8 +153,8 @@ func (r *PGRepository) StoreRefreshToken(ctx context.Context, token *RefreshToke
 }
 
 // GetRefreshToken retrieves a refresh token by ID.
-func (r *PGRepository) GetRefreshToken(ctx context.Context, id string) (*RefreshToken, error) {
-	rows, err := r.pool.Query(ctx,
+func (repo *PGRepository) GetRefreshToken(ctx context.Context, id string) (*RefreshToken, error) {
+	rows, err := repo.pool.Query(ctx,
 		`SELECT * FROM refresh_tokens WHERE id = $1`, id,
 	)
 	if err != nil {
@@ -171,8 +171,8 @@ func (r *PGRepository) GetRefreshToken(ctx context.Context, id string) (*Refresh
 }
 
 // RevokeRefreshToken marks a refresh token as revoked.
-func (r *PGRepository) RevokeRefreshToken(ctx context.Context, id string) error {
-	tag, err := r.pool.Exec(ctx,
+func (repo *PGRepository) RevokeRefreshToken(ctx context.Context, id string) error {
+	tag, err := repo.pool.Exec(ctx,
 		`UPDATE refresh_tokens SET revoked = true WHERE id = $1`, id,
 	)
 	if err != nil {
@@ -185,8 +185,8 @@ func (r *PGRepository) RevokeRefreshToken(ctx context.Context, id string) error 
 }
 
 // RevokeAllRefreshTokens revokes all active refresh tokens for a user.
-func (r *PGRepository) RevokeAllRefreshTokens(ctx context.Context, userAddress string) error {
-	_, err := r.pool.Exec(ctx,
+func (repo *PGRepository) RevokeAllRefreshTokens(ctx context.Context, userAddress string) error {
+	_, err := repo.pool.Exec(ctx,
 		`UPDATE refresh_tokens SET revoked = true
 		 WHERE user_address = $1 AND revoked = false`, userAddress,
 	)

--- a/internal/platform/market/domain.go
+++ b/internal/platform/market/domain.go
@@ -26,8 +26,8 @@ const (
 	EventTypeMultiOutcome EventType = 1
 )
 
-func (t EventType) String() string {
-	switch t {
+func (eventType EventType) String() string {
+	switch eventType {
 	case EventTypeBinary:
 		return "BINARY"
 	case EventTypeMultiOutcome:
@@ -38,8 +38,8 @@ func (t EventType) String() string {
 }
 
 // IsValid returns true if the event type is a known value.
-func (t EventType) IsValid() bool {
-	return t == EventTypeBinary || t == EventTypeMultiOutcome
+func (eventType EventType) IsValid() bool {
+	return eventType == EventTypeBinary || eventType == EventTypeMultiOutcome
 }
 
 // Status represents the lifecycle state of an event or market.
@@ -53,8 +53,8 @@ const (
 	StatusVoided   Status = 3
 )
 
-func (s Status) String() string {
-	switch s {
+func (status Status) String() string {
+	switch status {
 	case StatusActive:
 		return "ACTIVE"
 	case StatusPaused:
@@ -69,8 +69,8 @@ func (s Status) String() string {
 }
 
 // IsValid returns true if the status is a known value.
-func (s Status) IsValid() bool {
-	return s >= StatusActive && s <= StatusVoided
+func (status Status) IsValid() bool {
+	return status >= StatusActive && status <= StatusVoided
 }
 
 // Outcome represents the resolved outcome of a market.
@@ -82,8 +82,8 @@ const (
 	OutcomeNo  Outcome = 1
 )
 
-func (o Outcome) String() string {
-	switch o {
+func (outcome Outcome) String() string {
+	switch outcome {
 	case OutcomeYes:
 		return "YES"
 	case OutcomeNo:
@@ -94,8 +94,8 @@ func (o Outcome) String() string {
 }
 
 // IsValid returns true if the outcome is a known value.
-func (o Outcome) IsValid() bool {
-	return o == OutcomeYes || o == OutcomeNo
+func (outcome Outcome) IsValid() bool {
+	return outcome == OutcomeYes || outcome == OutcomeNo
 }
 
 // ValidTransition returns true if moving from one Status to another

--- a/internal/platform/market/pg_repository.go
+++ b/internal/platform/market/pg_repository.go
@@ -24,8 +24,8 @@ func NewPGRepository(pool *pgxpool.Pool) *PGRepository {
 
 // CreateCategory persists a new category. Returns ErrDuplicateSlug if the slug
 // already exists.
-func (r *PGRepository) CreateCategory(ctx context.Context, cat *Category) error {
-	_, err := r.pool.Exec(ctx,
+func (repo *PGRepository) CreateCategory(ctx context.Context, cat *Category) error {
+	_, err := repo.pool.Exec(ctx,
 		`INSERT INTO categories (name, slug) VALUES ($1, $2)`,
 		cat.Name, cat.Slug,
 	)
@@ -39,8 +39,8 @@ func (r *PGRepository) CreateCategory(ctx context.Context, cat *Category) error 
 }
 
 // GetCategory retrieves a category by ID. Returns ErrNotFound if not found.
-func (r *PGRepository) GetCategory(ctx context.Context, id string) (*Category, error) {
-	rows, err := r.pool.Query(ctx, `SELECT * FROM categories WHERE id = $1`, id)
+func (repo *PGRepository) GetCategory(ctx context.Context, id string) (*Category, error) {
+	rows, err := repo.pool.Query(ctx, `SELECT * FROM categories WHERE id = $1`, id)
 	if err != nil {
 		return nil, fmt.Errorf("getting category %s: %w", id, err)
 	}
@@ -55,8 +55,8 @@ func (r *PGRepository) GetCategory(ctx context.Context, id string) (*Category, e
 }
 
 // ListCategories returns all categories ordered by name.
-func (r *PGRepository) ListCategories(ctx context.Context) ([]*Category, error) {
-	rows, err := r.pool.Query(ctx, `SELECT * FROM categories ORDER BY name`)
+func (repo *PGRepository) ListCategories(ctx context.Context) ([]*Category, error) {
+	rows, err := repo.pool.Query(ctx, `SELECT * FROM categories ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("listing categories: %w", err)
 	}
@@ -70,11 +70,11 @@ func (r *PGRepository) ListCategories(ctx context.Context) ([]*Category, error) 
 // CreateEvent persists a new event. Validates input via ValidateEvent before
 // persisting. Returns ErrInvalidEvent for shape violations, ErrDuplicateSlug
 // if the slug already exists.
-func (r *PGRepository) CreateEvent(ctx context.Context, event *Event) error {
+func (repo *PGRepository) CreateEvent(ctx context.Context, event *Event) error {
 	if err := ValidateEvent(event, time.Now()); err != nil {
 		return fmt.Errorf("creating event: %w", err)
 	}
-	_, err := r.pool.Exec(ctx,
+	_, err := repo.pool.Exec(ctx,
 		`INSERT INTO events (
 			slug, title, description, category_id, event_type,
 			resolution_config, status, end_date, featured, featured_sort_order
@@ -93,8 +93,8 @@ func (r *PGRepository) CreateEvent(ctx context.Context, event *Event) error {
 }
 
 // GetEvent retrieves an event by ID. Returns ErrNotFound if not found.
-func (r *PGRepository) GetEvent(ctx context.Context, id string) (*Event, error) {
-	rows, err := r.pool.Query(ctx, `SELECT * FROM events WHERE id = $1`, id)
+func (repo *PGRepository) GetEvent(ctx context.Context, id string) (*Event, error) {
+	rows, err := repo.pool.Query(ctx, `SELECT * FROM events WHERE id = $1`, id)
 	if err != nil {
 		return nil, fmt.Errorf("getting event %s: %w", id, err)
 	}
@@ -109,8 +109,8 @@ func (r *PGRepository) GetEvent(ctx context.Context, id string) (*Event, error) 
 }
 
 // GetEventBySlug retrieves an event by slug. Returns ErrNotFound if not found.
-func (r *PGRepository) GetEventBySlug(ctx context.Context, slug string) (*Event, error) {
-	rows, err := r.pool.Query(ctx, `SELECT * FROM events WHERE slug = $1`, slug)
+func (repo *PGRepository) GetEventBySlug(ctx context.Context, slug string) (*Event, error) {
+	rows, err := repo.pool.Query(ctx, `SELECT * FROM events WHERE slug = $1`, slug)
 	if err != nil {
 		return nil, fmt.Errorf("getting event by slug %q: %w", slug, err)
 	}
@@ -125,16 +125,16 @@ func (r *PGRepository) GetEventBySlug(ctx context.Context, slug string) (*Event,
 }
 
 // ListEvents returns events optionally filtered by statuses.
-func (r *PGRepository) ListEvents(ctx context.Context, statuses []Status) ([]*Event, error) {
+func (repo *PGRepository) ListEvents(ctx context.Context, statuses []Status) ([]*Event, error) {
 	var rows pgx.Rows
 	var err error
 
 	if len(statuses) == 0 {
-		rows, err = r.pool.Query(ctx,
+		rows, err = repo.pool.Query(ctx,
 			`SELECT * FROM events ORDER BY created_at DESC`,
 		)
 	} else {
-		rows, err = r.pool.Query(ctx,
+		rows, err = repo.pool.Query(ctx,
 			`SELECT * FROM events WHERE status = ANY($1) ORDER BY created_at DESC`,
 			statusSlice(statuses),
 		)
@@ -152,11 +152,11 @@ func (r *PGRepository) ListEvents(ctx context.Context, statuses []Status) ([]*Ev
 // CreateMarket persists a new market. Validates input via ValidateMarket
 // before persisting. Returns ErrInvalidMarket for shape violations,
 // ErrDuplicateSlug if the slug already exists.
-func (r *PGRepository) CreateMarket(ctx context.Context, market *Market) error {
+func (repo *PGRepository) CreateMarket(ctx context.Context, market *Market) error {
 	if err := ValidateMarket(market); err != nil {
 		return fmt.Errorf("creating market: %w", err)
 	}
-	_, err := r.pool.Exec(ctx,
+	_, err := repo.pool.Exec(ctx,
 		`INSERT INTO markets (
 			slug, event_id, question, outcome_yes_label, outcome_no_label,
 			token_id_yes, token_id_no, condition_id, status, outcome,
@@ -178,8 +178,8 @@ func (r *PGRepository) CreateMarket(ctx context.Context, market *Market) error {
 }
 
 // GetMarket retrieves a market by ID. Returns ErrNotFound if not found.
-func (r *PGRepository) GetMarket(ctx context.Context, id string) (*Market, error) {
-	rows, err := r.pool.Query(ctx, `SELECT * FROM markets WHERE id = $1`, id)
+func (repo *PGRepository) GetMarket(ctx context.Context, id string) (*Market, error) {
+	rows, err := repo.pool.Query(ctx, `SELECT * FROM markets WHERE id = $1`, id)
 	if err != nil {
 		return nil, fmt.Errorf("getting market %s: %w", id, err)
 	}
@@ -194,8 +194,8 @@ func (r *PGRepository) GetMarket(ctx context.Context, id string) (*Market, error
 }
 
 // GetMarketBySlug retrieves a market by slug. Returns ErrNotFound if not found.
-func (r *PGRepository) GetMarketBySlug(ctx context.Context, slug string) (*Market, error) {
-	rows, err := r.pool.Query(ctx, `SELECT * FROM markets WHERE slug = $1`, slug)
+func (repo *PGRepository) GetMarketBySlug(ctx context.Context, slug string) (*Market, error) {
+	rows, err := repo.pool.Query(ctx, `SELECT * FROM markets WHERE slug = $1`, slug)
 	if err != nil {
 		return nil, fmt.Errorf("getting market by slug %q: %w", slug, err)
 	}
@@ -210,16 +210,16 @@ func (r *PGRepository) GetMarketBySlug(ctx context.Context, slug string) (*Marke
 }
 
 // ListMarkets returns markets optionally filtered by statuses.
-func (r *PGRepository) ListMarkets(ctx context.Context, statuses []Status) ([]*Market, error) {
+func (repo *PGRepository) ListMarkets(ctx context.Context, statuses []Status) ([]*Market, error) {
 	var rows pgx.Rows
 	var err error
 
 	if len(statuses) == 0 {
-		rows, err = r.pool.Query(ctx,
+		rows, err = repo.pool.Query(ctx,
 			`SELECT * FROM markets ORDER BY created_at DESC`,
 		)
 	} else {
-		rows, err = r.pool.Query(ctx,
+		rows, err = repo.pool.Query(ctx,
 			`SELECT * FROM markets WHERE status = ANY($1) ORDER BY created_at DESC`,
 			statusSlice(statuses),
 		)
@@ -235,8 +235,8 @@ func (r *PGRepository) ListMarkets(ctx context.Context, statuses []Status) ([]*M
 }
 
 // ListMarketsByEvent returns all markets belonging to an event.
-func (r *PGRepository) ListMarketsByEvent(ctx context.Context, eventID string) ([]*Market, error) {
-	rows, err := r.pool.Query(ctx,
+func (repo *PGRepository) ListMarketsByEvent(ctx context.Context, eventID string) ([]*Market, error) {
+	rows, err := repo.pool.Query(ctx,
 		`SELECT * FROM markets WHERE event_id = $1 ORDER BY created_at DESC`,
 		eventID,
 	)
@@ -252,8 +252,8 @@ func (r *PGRepository) ListMarketsByEvent(ctx context.Context, eventID string) (
 
 // UpdateStatus changes the status of a market. Validates the transition
 // before executing the update.
-func (r *PGRepository) UpdateStatus(ctx context.Context, id string, status Status) error {
-	tx, err := r.pool.Begin(ctx)
+func (repo *PGRepository) UpdateStatus(ctx context.Context, id string, status Status) error {
+	tx, err := repo.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("updating market status: beginning transaction: %w", err)
 	}
@@ -289,8 +289,8 @@ func (r *PGRepository) UpdateStatus(ctx context.Context, id string, status Statu
 }
 
 // UpdateMarketPrices updates the current prices, volume, and open interest.
-func (r *PGRepository) UpdateMarketPrices(ctx context.Context, id string, priceYes, priceNo, volume, openInterest int64) error {
-	tag, err := r.pool.Exec(ctx,
+func (repo *PGRepository) UpdateMarketPrices(ctx context.Context, id string, priceYes, priceNo, volume, openInterest int64) error {
+	tag, err := repo.pool.Exec(ctx,
 		`UPDATE markets SET price_yes = $1, price_no = $2, volume = $3,
 		 open_interest = $4, updated_at = now() WHERE id = $5`,
 		priceYes, priceNo, volume, openInterest, id,
@@ -307,8 +307,8 @@ func (r *PGRepository) UpdateMarketPrices(ctx context.Context, id string, priceY
 // statusSlice converts Status values to int16 for pgx ANY() binding.
 func statusSlice(statuses []Status) []int16 {
 	out := make([]int16, len(statuses))
-	for i, s := range statuses {
-		out[i] = int16(s)
+	for idx, status := range statuses {
+		out[idx] = int16(status)
 	}
 	return out
 }

--- a/internal/platform/market/validate_test.go
+++ b/internal/platform/market/validate_test.go
@@ -24,44 +24,44 @@ func TestValidateEvent(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		modify  func(e *Event)
+		modify  func(event *Event)
 		wantErr bool
 	}{
 		{
 			name:    "valid event passes",
-			modify:  func(e *Event) {},
+			modify:  func(event *Event) {},
 			wantErr: false,
 		},
 		{
 			name:    "empty slug",
-			modify:  func(e *Event) { e.Slug = "" },
+			modify:  func(event *Event) { event.Slug = "" },
 			wantErr: true,
 		},
 		{
 			name:    "empty title",
-			modify:  func(e *Event) { e.Title = "" },
+			modify:  func(event *Event) { event.Title = "" },
 			wantErr: true,
 		},
 		{
 			name:    "end date in the past",
-			modify:  func(e *Event) { e.EndDate = time.Now().Add(-1 * time.Hour) },
+			modify:  func(event *Event) { event.EndDate = time.Now().Add(-1 * time.Hour) },
 			wantErr: true,
 		},
 		{
 			name:    "invalid event type",
-			modify:  func(e *Event) { e.EventType = EventType(99) },
+			modify:  func(event *Event) { event.EventType = EventType(99) },
 			wantErr: true,
 		},
 		{
 			name:    "invalid status",
-			modify:  func(e *Event) { e.Status = Status(99) },
+			modify:  func(event *Event) { event.Status = Status(99) },
 			wantErr: true,
 		},
 		{
 			name: "with category ID is valid",
-			modify: func(e *Event) {
+			modify: func(event *Event) {
 				catID := "550e8400-e29b-41d4-a716-446655440000"
-				e.CategoryID = &catID
+				event.CategoryID = &catID
 			},
 			wantErr: false,
 		},
@@ -70,9 +70,9 @@ func TestValidateEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			e := validEvent()
-			tt.modify(e)
-			err := ValidateEvent(e, time.Now())
+			event := validEvent()
+			tt.modify(event)
+			err := ValidateEvent(event, time.Now())
 			if tt.wantErr && err == nil {
 				t.Error("expected error, got nil")
 			}
@@ -106,59 +106,59 @@ func TestValidateMarket(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		modify  func(m *Market)
+		modify  func(market *Market)
 		wantErr bool
 	}{
 		{
 			name:    "valid market passes",
-			modify:  func(m *Market) {},
+			modify:  func(market *Market) {},
 			wantErr: false,
 		},
 		{
 			name:    "empty slug",
-			modify:  func(m *Market) { m.Slug = "" },
+			modify:  func(market *Market) { market.Slug = "" },
 			wantErr: true,
 		},
 		{
 			name:    "empty question",
-			modify:  func(m *Market) { m.Question = "" },
+			modify:  func(market *Market) { market.Question = "" },
 			wantErr: true,
 		},
 		{
 			name:    "empty yes label",
-			modify:  func(m *Market) { m.OutcomeYesLabel = "" },
+			modify:  func(market *Market) { market.OutcomeYesLabel = "" },
 			wantErr: true,
 		},
 		{
 			name:    "empty no label",
-			modify:  func(m *Market) { m.OutcomeNoLabel = "" },
+			modify:  func(market *Market) { market.OutcomeNoLabel = "" },
 			wantErr: true,
 		},
 		{
 			name:    "invalid status",
-			modify:  func(m *Market) { m.Status = Status(99) },
+			modify:  func(market *Market) { market.Status = Status(99) },
 			wantErr: true,
 		},
 		{
 			name:    "empty token ID yes",
-			modify:  func(m *Market) { m.TokenIDYes = "" },
+			modify:  func(market *Market) { market.TokenIDYes = "" },
 			wantErr: true,
 		},
 		{
 			name:    "empty token ID no",
-			modify:  func(m *Market) { m.TokenIDNo = "" },
+			modify:  func(market *Market) { market.TokenIDNo = "" },
 			wantErr: true,
 		},
 		{
 			name:    "empty condition ID",
-			modify:  func(m *Market) { m.ConditionID = "" },
+			modify:  func(market *Market) { market.ConditionID = "" },
 			wantErr: true,
 		},
 		{
 			name: "with event ID is valid",
-			modify: func(m *Market) {
+			modify: func(market *Market) {
 				eventID := "550e8400-e29b-41d4-a716-446655440000"
-				m.EventID = &eventID
+				market.EventID = &eventID
 			},
 			wantErr: false,
 		},
@@ -167,9 +167,9 @@ func TestValidateMarket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m := validMarket()
-			tt.modify(m)
-			err := ValidateMarket(m)
+			market := validMarket()
+			tt.modify(market)
+			err := ValidateMarket(market)
 			if tt.wantErr && err == nil {
 				t.Error("expected error, got nil")
 			}

--- a/internal/shared/grpc/health.go
+++ b/internal/shared/grpc/health.go
@@ -30,13 +30,13 @@ func NewPoolHealthChecker(pool interface {
 }
 
 // Check pings the database to verify connectivity.
-func (c *PoolHealthChecker) Check(ctx context.Context) error {
-	return c.pool.Ping(ctx)
+func (checker *PoolHealthChecker) Check(ctx context.Context) error {
+	return checker.pool.Ping(ctx)
 }
 
 // WatchHealth periodically checks the given HealthChecker and updates the
 // gRPC health server status. It blocks until ctx is cancelled.
-func WatchHealth(ctx context.Context, hs *health.Server, serviceName string, checker HealthChecker, interval time.Duration, logger *zap.Logger) {
+func WatchHealth(ctx context.Context, healthServer *health.Server, serviceName string, checker HealthChecker, interval time.Duration, logger *zap.Logger) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -51,9 +51,9 @@ func WatchHealth(ctx context.Context, hs *health.Server, serviceName string, che
 
 			if err != nil {
 				logger.Warn("health check failed", zap.Error(err))
-				hs.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)
+				healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)
 			} else {
-				hs.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
+				healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
 			}
 		}
 	}

--- a/internal/shared/grpc/health_test.go
+++ b/internal/shared/grpc/health_test.go
@@ -19,33 +19,33 @@ type mockChecker struct {
 	err error
 }
 
-func (m *mockChecker) Check(_ context.Context) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.err
+func (checker *mockChecker) Check(_ context.Context) error {
+	checker.mu.Lock()
+	defer checker.mu.Unlock()
+	return checker.err
 }
 
-func (m *mockChecker) setErr(err error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.err = err
+func (checker *mockChecker) setErr(err error) {
+	checker.mu.Lock()
+	defer checker.mu.Unlock()
+	checker.err = err
 }
 
 func TestWatchHealth_SetsServing(t *testing.T) {
 	t.Parallel()
 
-	hs := health.NewServer()
+	healthServer := health.NewServer()
 	checker := &mockChecker{}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go sharedgrpc.WatchHealth(ctx, hs, "test", checker, 10*time.Millisecond, zap.NewNop())
+	go sharedgrpc.WatchHealth(ctx, healthServer, "test", checker, 10*time.Millisecond, zap.NewNop())
 
 	// Wait for at least one tick.
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := hs.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
+	resp, err := healthServer.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}
@@ -57,13 +57,13 @@ func TestWatchHealth_SetsServing(t *testing.T) {
 func TestWatchHealth_TransitionsToNotServing(t *testing.T) {
 	t.Parallel()
 
-	hs := health.NewServer()
+	healthServer := health.NewServer()
 	checker := &mockChecker{}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go sharedgrpc.WatchHealth(ctx, hs, "test", checker, 10*time.Millisecond, zap.NewNop())
+	go sharedgrpc.WatchHealth(ctx, healthServer, "test", checker, 10*time.Millisecond, zap.NewNop())
 
 	// Let it become healthy first.
 	time.Sleep(50 * time.Millisecond)
@@ -72,7 +72,7 @@ func TestWatchHealth_TransitionsToNotServing(t *testing.T) {
 	checker.setErr(errors.New("db gone"))
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := hs.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
+	resp, err := healthServer.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}
@@ -84,18 +84,18 @@ func TestWatchHealth_TransitionsToNotServing(t *testing.T) {
 func TestWatchHealth_RecoversAfterFailure(t *testing.T) {
 	t.Parallel()
 
-	hs := health.NewServer()
+	healthServer := health.NewServer()
 	checker := &mockChecker{err: errors.New("initial failure")}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go sharedgrpc.WatchHealth(ctx, hs, "test", checker, 10*time.Millisecond, zap.NewNop())
+	go sharedgrpc.WatchHealth(ctx, healthServer, "test", checker, 10*time.Millisecond, zap.NewNop())
 
 	// Wait for NOT_SERVING.
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := hs.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
+	resp, err := healthServer.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestWatchHealth_RecoversAfterFailure(t *testing.T) {
 	checker.setErr(nil)
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err = hs.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
+	resp, err = healthServer.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}

--- a/internal/shared/httputil/json.go
+++ b/internal/shared/httputil/json.go
@@ -16,8 +16,8 @@ const maxBodySize = 1 << 20
 // DecodeJSON reads the request body as JSON into dst. It enforces a 1 MB size
 // limit and rejects unknown fields. Returns an error suitable for direct use
 // in an ErrorResponse if the body is empty, oversized, or malformed.
-func DecodeJSON(r *http.Request, dst any) error {
-	reader := http.MaxBytesReader(nil, r.Body, maxBodySize)
+func DecodeJSON(request *http.Request, dst any) error {
+	reader := http.MaxBytesReader(nil, request.Body, maxBodySize)
 	defer func() { _ = reader.Close() }()
 
 	dec := json.NewDecoder(reader)
@@ -38,10 +38,10 @@ func DecodeJSON(r *http.Request, dst any) error {
 
 // EncodeJSON writes data as a JSON response with the given HTTP status code.
 // Sets Content-Type to application/json before writing the status header.
-func EncodeJSON(w http.ResponseWriter, status int, data any) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(data); err != nil {
+func EncodeJSON(writer http.ResponseWriter, status int, data any) error {
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(status)
+	if err := json.NewEncoder(writer).Encode(data); err != nil {
 		return fmt.Errorf("encoding JSON response: %w", err)
 	}
 	return nil
@@ -54,6 +54,6 @@ type errorEnvelope struct {
 
 // ErrorResponse writes a JSON error response with the given status code
 // and message. Uses the standard {"error": "..."} envelope.
-func ErrorResponse(w http.ResponseWriter, status int, msg string) {
-	_ = EncodeJSON(w, status, errorEnvelope{Error: msg})
+func ErrorResponse(writer http.ResponseWriter, status int, msg string) {
+	_ = EncodeJSON(writer, status, errorEnvelope{Error: msg})
 }

--- a/internal/shared/httputil/middleware.go
+++ b/internal/shared/httputil/middleware.go
@@ -33,20 +33,20 @@ type statusWriter struct {
 	written bool
 }
 
-func (sw *statusWriter) WriteHeader(code int) {
-	if !sw.written {
-		sw.code = code
-		sw.written = true
+func (writer *statusWriter) WriteHeader(code int) {
+	if !writer.written {
+		writer.code = code
+		writer.written = true
 	}
-	sw.ResponseWriter.WriteHeader(code)
+	writer.ResponseWriter.WriteHeader(code)
 }
 
-func (sw *statusWriter) Write(b []byte) (int, error) {
-	if !sw.written {
-		sw.code = http.StatusOK
-		sw.written = true
+func (writer *statusWriter) Write(data []byte) (int, error) {
+	if !writer.written {
+		writer.code = http.StatusOK
+		writer.written = true
 	}
-	return sw.ResponseWriter.Write(b)
+	return writer.ResponseWriter.Write(data)
 }
 
 // Logging returns HTTP middleware that logs each request with method, path,
@@ -55,14 +55,14 @@ func Logging(logger *zap.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
-			sw := &statusWriter{ResponseWriter: w, code: http.StatusOK}
+			writer := &statusWriter{ResponseWriter: w, code: http.StatusOK}
 
-			next.ServeHTTP(sw, r)
+			next.ServeHTTP(writer, r)
 
 			logger.Info("http request",
 				zap.String("method", r.Method),
 				zap.String("path", r.URL.Path),
-				zap.Int("status", sw.code),
+				zap.Int("status", writer.code),
 				zap.Duration("duration", time.Since(start)),
 				zap.String("request_id", observability.RequestIDFrom(r.Context())),
 			)

--- a/internal/shared/nats/client.go
+++ b/internal/shared/nats/client.go
@@ -19,9 +19,9 @@ type ClientConfig struct {
 
 // Client wraps a NATS connection and JetStream context.
 type Client struct {
-	conn   *nats.Conn
-	js     nats.JetStreamContext
-	logger *zap.Logger
+	conn      *nats.Conn
+	jetStream nats.JetStreamContext
+	logger    *zap.Logger
 }
 
 // NewClient connects to NATS, creates a JetStream context, and sets up
@@ -54,16 +54,16 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		return nil, fmt.Errorf("connecting to NATS at %s: %w", cfg.URL, err)
 	}
 
-	js, err := conn.JetStream()
+	jetStream, err := conn.JetStream()
 	if err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("creating JetStream context: %w", err)
 	}
 
 	return &Client{
-		conn:   conn,
-		js:     js,
-		logger: logger,
+		conn:      conn,
+		jetStream: jetStream,
+		logger:    logger,
 	}, nil
 }
 
@@ -78,23 +78,23 @@ func ClientFromEnv(logger *zap.Logger, name string) (*Client, error) {
 }
 
 // Conn returns the underlying NATS connection.
-func (c *Client) Conn() *nats.Conn {
-	return c.conn
+func (client *Client) Conn() *nats.Conn {
+	return client.conn
 }
 
 // JetStream returns the JetStream context.
-func (c *Client) JetStream() nats.JetStreamContext {
-	return c.js
+func (client *Client) JetStream() nats.JetStreamContext {
+	return client.jetStream
 }
 
 // Close drains the connection and then closes it.
-func (c *Client) Close() {
-	if err := c.conn.Drain(); err != nil {
-		c.logger.Warn("error draining NATS connection", zap.Error(err))
+func (client *Client) Close() {
+	if err := client.conn.Drain(); err != nil {
+		client.logger.Warn("error draining NATS connection", zap.Error(err))
 	}
 }
 
 // Drain initiates a graceful drain of the connection.
-func (c *Client) Drain() error {
-	return c.conn.Drain()
+func (client *Client) Drain() error {
+	return client.conn.Drain()
 }

--- a/internal/shared/nats/publish.go
+++ b/internal/shared/nats/publish.go
@@ -11,7 +11,7 @@ import (
 
 // Publish sends a message on Core NATS with OpenTelemetry trace context
 // injected into the message headers.
-func (c *Client) Publish(ctx context.Context, subject string, data []byte) error {
+func (client *Client) Publish(ctx context.Context, subject string, data []byte) error {
 	msg := &nats.Msg{
 		Subject: subject,
 		Data:    data,
@@ -20,7 +20,7 @@ func (c *Client) Publish(ctx context.Context, subject string, data []byte) error
 
 	injectTraceContext(ctx, msg)
 
-	if err := c.conn.PublishMsg(msg); err != nil {
+	if err := client.conn.PublishMsg(msg); err != nil {
 		return fmt.Errorf("publishing to %s: %w", subject, err)
 	}
 	return nil
@@ -28,7 +28,7 @@ func (c *Client) Publish(ctx context.Context, subject string, data []byte) error
 
 // JetStreamPublish sends a message via JetStream with OpenTelemetry trace
 // context injected into the message headers.
-func (c *Client) JetStreamPublish(ctx context.Context, subject string, data []byte, opts ...nats.PubOpt) (*nats.PubAck, error) {
+func (client *Client) JetStreamPublish(ctx context.Context, subject string, data []byte, opts ...nats.PubOpt) (*nats.PubAck, error) {
 	msg := &nats.Msg{
 		Subject: subject,
 		Data:    data,
@@ -37,7 +37,7 @@ func (c *Client) JetStreamPublish(ctx context.Context, subject string, data []by
 
 	injectTraceContext(ctx, msg)
 
-	ack, err := c.js.PublishMsg(msg, opts...)
+	ack, err := client.jetStream.PublishMsg(msg, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("JetStream publishing to %s: %w", subject, err)
 	}

--- a/internal/shared/nats/stream.go
+++ b/internal/shared/nats/stream.go
@@ -18,7 +18,7 @@ type StreamConfig struct {
 }
 
 // EnsureStream creates or updates a JetStream stream (idempotent).
-func (c *Client) EnsureStream(cfg StreamConfig) (*nats.StreamInfo, error) {
+func (client *Client) EnsureStream(cfg StreamConfig) (*nats.StreamInfo, error) {
 	if cfg.Name == "" {
 		return nil, fmt.Errorf("creating stream: name is required")
 	}
@@ -43,16 +43,16 @@ func (c *Client) EnsureStream(cfg StreamConfig) (*nats.StreamInfo, error) {
 	}
 
 	// Try to update first; if stream doesn't exist, create it.
-	info, err := c.js.StreamInfo(cfg.Name)
+	info, err := client.jetStream.StreamInfo(cfg.Name)
 	if err == nil && info != nil {
-		info, err = c.js.UpdateStream(jsCfg)
+		info, err = client.jetStream.UpdateStream(jsCfg)
 		if err != nil {
 			return nil, fmt.Errorf("updating stream %s: %w", cfg.Name, err)
 		}
 		return info, nil
 	}
 
-	info, err = c.js.AddStream(jsCfg)
+	info, err = client.jetStream.AddStream(jsCfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating stream %s: %w", cfg.Name, err)
 	}
@@ -60,7 +60,7 @@ func (c *Client) EnsureStream(cfg StreamConfig) (*nats.StreamInfo, error) {
 }
 
 // EnsureConsumer creates or updates a JetStream consumer (idempotent).
-func (c *Client) EnsureConsumer(stream string, cfg *nats.ConsumerConfig) (*nats.ConsumerInfo, error) {
+func (client *Client) EnsureConsumer(stream string, cfg *nats.ConsumerConfig) (*nats.ConsumerInfo, error) {
 	if stream == "" {
 		return nil, fmt.Errorf("creating consumer: stream name is required")
 	}
@@ -68,7 +68,7 @@ func (c *Client) EnsureConsumer(stream string, cfg *nats.ConsumerConfig) (*nats.
 		return nil, fmt.Errorf("creating consumer on %s: config is required", stream)
 	}
 
-	info, err := c.js.AddConsumer(stream, cfg)
+	info, err := client.jetStream.AddConsumer(stream, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating consumer %s on %s: %w", cfg.Durable, stream, err)
 	}

--- a/internal/shared/nats/subscribe.go
+++ b/internal/shared/nats/subscribe.go
@@ -14,46 +14,46 @@ type MessageHandler func(ctx context.Context, msg *nats.Msg) error
 
 // Subscribe creates a Core NATS subscription that extracts OpenTelemetry trace
 // context from message headers before invoking the handler.
-func (c *Client) Subscribe(subject string, handler MessageHandler) (*nats.Subscription, error) {
-	return c.conn.Subscribe(subject, c.wrapHandler(handler))
+func (client *Client) Subscribe(subject string, handler MessageHandler) (*nats.Subscription, error) {
+	return client.conn.Subscribe(subject, client.wrapHandler(handler))
 }
 
 // QueueSubscribe creates a queue group subscription that extracts OpenTelemetry
 // trace context from message headers before invoking the handler.
-func (c *Client) QueueSubscribe(subject, queue string, handler MessageHandler) (*nats.Subscription, error) {
-	return c.conn.QueueSubscribe(subject, queue, c.wrapHandler(handler))
+func (client *Client) QueueSubscribe(subject, queue string, handler MessageHandler) (*nats.Subscription, error) {
+	return client.conn.QueueSubscribe(subject, queue, client.wrapHandler(handler))
 }
 
 // JetStreamSubscribe creates a JetStream subscription that extracts trace
 // context, calls the handler, and acks/naks based on the result.
-func (c *Client) JetStreamSubscribe(subject string, handler MessageHandler, opts ...nats.SubOpt) (*nats.Subscription, error) {
-	return c.js.Subscribe(subject, func(msg *nats.Msg) {
+func (client *Client) JetStreamSubscribe(subject string, handler MessageHandler, opts ...nats.SubOpt) (*nats.Subscription, error) {
+	return client.jetStream.Subscribe(subject, func(msg *nats.Msg) {
 		ctx := extractTraceContext(context.Background(), msg)
 
 		if err := handler(ctx, msg); err != nil {
-			c.logger.Error("JetStream handler error",
+			client.logger.Error("JetStream handler error",
 				zap.String("subject", subject),
 				zap.Error(err),
 			)
 			if nakErr := msg.Nak(); nakErr != nil {
-				c.logger.Warn("failed to nak message", zap.Error(nakErr))
+				client.logger.Warn("failed to nak message", zap.Error(nakErr))
 			}
 			return
 		}
 		if ackErr := msg.Ack(); ackErr != nil {
-			c.logger.Warn("failed to ack message", zap.Error(ackErr))
+			client.logger.Warn("failed to ack message", zap.Error(ackErr))
 		}
 	}, opts...)
 }
 
 // wrapHandler returns a nats.MsgHandler that extracts trace context and
 // invokes the MessageHandler.
-func (c *Client) wrapHandler(handler MessageHandler) nats.MsgHandler {
+func (client *Client) wrapHandler(handler MessageHandler) nats.MsgHandler {
 	return func(msg *nats.Msg) {
 		ctx := extractTraceContext(context.Background(), msg)
 
 		if err := handler(ctx, msg); err != nil {
-			c.logger.Error("NATS handler error",
+			client.logger.Error("NATS handler error",
 				zap.String("subject", msg.Subject),
 				zap.Error(err),
 			)

--- a/internal/shared/observability/metrics.go
+++ b/internal/shared/observability/metrics.go
@@ -113,6 +113,6 @@ func NewMetrics(serviceName string) *Metrics {
 }
 
 // Handler returns the Prometheus metrics HTTP handler.
-func (m *Metrics) Handler() http.Handler {
+func (metrics *Metrics) Handler() http.Handler {
 	return promhttp.Handler()
 }

--- a/internal/shared/ratelimit/config.go
+++ b/internal/shared/ratelimit/config.go
@@ -55,49 +55,49 @@ func DefaultProfiles() []Profile {
 // For a profile named "X", env vars are RATELIMIT_X_RPM, RATELIMIT_X_BURST,
 // RATELIMIT_X_MAX_FAILURES, RATELIMIT_X_LOCKOUT_SECONDS, RATELIMIT_X_MAX_ENTRIES.
 func LoadProfilesFromEnv() []Profile {
-	ps := DefaultProfiles()
-	for i := range ps {
-		p := &ps[i]
-		prefix := "RATELIMIT_" + strings.ToUpper(p.Name)
+	profiles := DefaultProfiles()
+	for idx := range profiles {
+		profile := &profiles[idx]
+		prefix := "RATELIMIT_" + strings.ToUpper(profile.Name)
 		if rpm := readPositiveInt(prefix + "_RPM"); rpm > 0 {
-			p.Rate = rate.Every(time.Minute / time.Duration(rpm))
+			profile.Rate = rate.Every(time.Minute / time.Duration(rpm))
 		}
-		if b := readPositiveInt(prefix + "_BURST"); b > 0 {
-			p.Burst = b
+		if burst := readPositiveInt(prefix + "_BURST"); burst > 0 {
+			profile.Burst = burst
 		}
-		if f := readNonNegativeInt(prefix + "_MAX_FAILURES"); f >= 0 {
-			p.MaxFailures = f
+		if failures := readNonNegativeInt(prefix + "_MAX_FAILURES"); failures >= 0 {
+			profile.MaxFailures = failures
 		}
-		if s := readNonNegativeInt(prefix + "_LOCKOUT_SECONDS"); s >= 0 {
-			p.LockoutDuration = time.Duration(s) * time.Second
+		if seconds := readNonNegativeInt(prefix + "_LOCKOUT_SECONDS"); seconds >= 0 {
+			profile.LockoutDuration = time.Duration(seconds) * time.Second
 		}
-		if m := readPositiveInt(prefix + "_MAX_ENTRIES"); m > 0 {
-			p.MaxEntries = m
+		if maxEntries := readPositiveInt(prefix + "_MAX_ENTRIES"); maxEntries > 0 {
+			profile.MaxEntries = maxEntries
 		}
 	}
-	return ps
+	return profiles
 }
 
 // SweepIntervalFromEnv reads RATELIMIT_SWEEP_INTERVAL_SECONDS (default 60).
 func SweepIntervalFromEnv() time.Duration {
-	if s := readPositiveInt("RATELIMIT_SWEEP_INTERVAL_SECONDS"); s > 0 {
-		return time.Duration(s) * time.Second
+	if seconds := readPositiveInt("RATELIMIT_SWEEP_INTERVAL_SECONDS"); seconds > 0 {
+		return time.Duration(seconds) * time.Second
 	}
 	return 60 * time.Second
 }
 
 // SweepBatchSizeFromEnv reads RATELIMIT_SWEEP_BATCH_SIZE (default 500).
 func SweepBatchSizeFromEnv() int {
-	if s := readPositiveInt("RATELIMIT_SWEEP_BATCH_SIZE"); s > 0 {
-		return s
+	if size := readPositiveInt("RATELIMIT_SWEEP_BATCH_SIZE"); size > 0 {
+		return size
 	}
 	return 500
 }
 
 // LockoutsMaxFromEnv reads RATELIMIT_LOCKOUTS_MAX_ENTRIES (default 10,000).
 func LockoutsMaxFromEnv() int {
-	if s := readPositiveInt("RATELIMIT_LOCKOUTS_MAX_ENTRIES"); s > 0 {
-		return s
+	if maxEntries := readPositiveInt("RATELIMIT_LOCKOUTS_MAX_ENTRIES"); maxEntries > 0 {
+		return maxEntries
 	}
 	return 10_000
 }
@@ -108,25 +108,25 @@ func TrustProxyFromEnv() bool {
 }
 
 func readPositiveInt(key string) int {
-	v := envutil.Get(key, "")
-	if v == "" {
+	raw := envutil.Get(key, "")
+	if raw == "" {
 		return 0
 	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n <= 0 {
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed <= 0 {
 		return 0
 	}
-	return n
+	return parsed
 }
 
 func readNonNegativeInt(key string) int {
-	v := envutil.Get(key, "")
-	if v == "" {
+	raw := envutil.Get(key, "")
+	if raw == "" {
 		return -1
 	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n < 0 {
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 0 {
 		return -1
 	}
-	return n
+	return parsed
 }

--- a/internal/shared/ratelimit/helpers_test.go
+++ b/internal/shared/ratelimit/helpers_test.go
@@ -9,11 +9,11 @@ import (
 
 // testCounterValue reads the current value of a Prometheus counter. Useful
 // for asserting that a metric fired without scraping /metrics.
-func testCounterValue(t *testing.T, c prometheus.Counter) float64 {
+func testCounterValue(t *testing.T, counter prometheus.Counter) float64 {
 	t.Helper()
-	var m dto.Metric
-	if err := c.Write(&m); err != nil {
+	var metric dto.Metric
+	if err := counter.Write(&metric); err != nil {
 		t.Fatalf("reading counter: %v", err)
 	}
-	return m.GetCounter().GetValue()
+	return metric.GetCounter().GetValue()
 }

--- a/internal/shared/ratelimit/limiter.go
+++ b/internal/shared/ratelimit/limiter.go
@@ -91,21 +91,21 @@ func NewLimiter(cfg Config) (*Limiter, error) {
 	profiles := make(map[string]*Profile, len(cfg.Profiles))
 	ipEntries := make(map[string]map[string]*entry, len(cfg.Profiles))
 	userEntries := make(map[string]map[string]*entry, len(cfg.Profiles))
-	for i := range cfg.Profiles {
-		p := cfg.Profiles[i]
-		if p.Name == "" {
+	for idx := range cfg.Profiles {
+		profile := cfg.Profiles[idx]
+		if profile.Name == "" {
 			return nil, fmt.Errorf("ratelimit: profile with empty name")
 		}
-		if _, dup := profiles[p.Name]; dup {
-			return nil, fmt.Errorf("ratelimit: duplicate profile name %q", p.Name)
+		if _, dup := profiles[profile.Name]; dup {
+			return nil, fmt.Errorf("ratelimit: duplicate profile name %q", profile.Name)
 		}
-		if p.Rate <= 0 || p.Burst <= 0 {
-			return nil, fmt.Errorf("ratelimit: profile %q has non-positive Rate/Burst", p.Name)
+		if profile.Rate <= 0 || profile.Burst <= 0 {
+			return nil, fmt.Errorf("ratelimit: profile %q has non-positive Rate/Burst", profile.Name)
 		}
-		pCopy := p
-		profiles[p.Name] = &pCopy
-		ipEntries[p.Name] = make(map[string]*entry)
-		userEntries[p.Name] = make(map[string]*entry)
+		profileCopy := profile
+		profiles[profile.Name] = &profileCopy
+		ipEntries[profile.Name] = make(map[string]*entry)
+		userEntries[profile.Name] = make(map[string]*entry)
 	}
 	clock := cfg.Clock
 	if clock == nil {
@@ -136,41 +136,41 @@ func NewLimiter(cfg Config) (*Limiter, error) {
 }
 
 // Profile returns the named profile, or (nil, false) if unknown.
-func (l *Limiter) Profile(name string) (*Profile, bool) {
-	p, ok := l.profiles[name]
-	return p, ok
+func (limiter *Limiter) Profile(name string) (*Profile, bool) {
+	profile, ok := limiter.profiles[name]
+	return profile, ok
 }
 
-// AllowIP consumes one token from the per-IP bucket for p.
+// AllowIP consumes one token from the per-IP bucket for profile.
 // Returns (true, 0) on allow, (false, retryAfter) on reject.
-func (l *Limiter) AllowIP(p *Profile, ip string) (bool, time.Duration) {
-	return l.allow(l.ipEntries[p.Name], p, ip, keyTypeIP)
+func (limiter *Limiter) AllowIP(profile *Profile, ip string) (bool, time.Duration) {
+	return limiter.allow(limiter.ipEntries[profile.Name], profile, ip, keyTypeIP)
 }
 
-// AllowUser consumes one token from the per-user bucket for p.
-func (l *Limiter) AllowUser(p *Profile, addr string) (bool, time.Duration) {
-	return l.allow(l.userEntries[p.Name], p, addr, keyTypeUser)
+// AllowUser consumes one token from the per-user bucket for profile.
+func (limiter *Limiter) AllowUser(profile *Profile, addr string) (bool, time.Duration) {
+	return limiter.allow(limiter.userEntries[profile.Name], profile, addr, keyTypeUser)
 }
 
-func (l *Limiter) allow(m map[string]*entry, p *Profile, key, keyType string) (bool, time.Duration) {
-	now := l.clock()
-	l.mu.RLock()
-	e, ok := m[key]
-	l.mu.RUnlock()
+func (limiter *Limiter) allow(entries map[string]*entry, profile *Profile, key, keyType string) (bool, time.Duration) {
+	now := limiter.clock()
+	limiter.mu.RLock()
+	bucket, ok := entries[key]
+	limiter.mu.RUnlock()
 	if !ok {
-		l.mu.Lock()
-		if e, ok = m[key]; !ok {
-			if p.MaxEntries > 0 && len(m) >= p.MaxEntries {
-				l.evictOne(m, p.Name, keyType)
+		limiter.mu.Lock()
+		if bucket, ok = entries[key]; !ok {
+			if profile.MaxEntries > 0 && len(entries) >= profile.MaxEntries {
+				limiter.evictOne(entries, profile.Name, keyType)
 			}
-			e = &entry{lim: rate.NewLimiter(p.Rate, p.Burst)}
-			m[key] = e
+			bucket = &entry{lim: rate.NewLimiter(profile.Rate, profile.Burst)}
+			entries[key] = bucket
 		}
-		l.mu.Unlock()
+		limiter.mu.Unlock()
 	}
-	e.lastSeen.Store(now.UnixNano())
-	res := e.lim.ReserveN(now, 1)
-	delay := res.DelayFrom(now)
+	bucket.lastSeen.Store(now.UnixNano())
+	reservation := bucket.lim.ReserveN(now, 1)
+	delay := reservation.DelayFrom(now)
 	if delay == 0 {
 		return true, 0
 	}
@@ -178,69 +178,69 @@ func (l *Limiter) allow(m map[string]*entry, p *Profile, key, keyType string) (b
 	// for it. CancelAt must receive the same clock we used for ReserveN;
 	// res.Cancel() internally uses time.Now() and would corrupt state under
 	// an injected clock.
-	res.CancelAt(now)
+	reservation.CancelAt(now)
 	return false, delay
 }
 
 // IsLockedOut reports whether ip is currently locked out and the remaining time.
-func (l *Limiter) IsLockedOut(ip string) (bool, time.Duration) {
-	now := l.clock()
-	l.mu.RLock()
-	ls, ok := l.lockouts[ip]
-	l.mu.RUnlock()
+func (limiter *Limiter) IsLockedOut(ip string) (bool, time.Duration) {
+	now := limiter.clock()
+	limiter.mu.RLock()
+	state, ok := limiter.lockouts[ip]
+	limiter.mu.RUnlock()
 	if !ok {
 		return false, 0
 	}
-	if !now.Before(ls.until) {
+	if !now.Before(state.until) {
 		return false, 0
 	}
-	return true, ls.until.Sub(now)
+	return true, state.until.Sub(now)
 }
 
 // RecordAuthFailure bumps the failure counter for ip. When MaxFailures occur
-// within failureTTL, a lockout of p.LockoutDuration begins. No-op if p
-// disables lockout.
+// within failureTTL, a lockout of profile.LockoutDuration begins. No-op if
+// profile disables lockout.
 //
 // Sliding-window semantics: a failure older than failureTTL resets the count,
 // preventing ancient probes from contributing to a future lockout.
-func (l *Limiter) RecordAuthFailure(ip string, p *Profile) {
-	if p.MaxFailures <= 0 || p.LockoutDuration <= 0 {
+func (limiter *Limiter) RecordAuthFailure(ip string, profile *Profile) {
+	if profile.MaxFailures <= 0 || profile.LockoutDuration <= 0 {
 		return
 	}
-	now := l.clock()
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if ls, already := l.lockouts[ip]; already && now.Before(ls.until) {
+	now := limiter.clock()
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+	if state, already := limiter.lockouts[ip]; already && now.Before(state.until) {
 		return
 	}
 
-	fe := l.failures[ip]
-	if now.Sub(fe.lastFailure) > failureTTL {
-		fe.count = 0
+	failure := limiter.failures[ip]
+	if now.Sub(failure.lastFailure) > failureTTL {
+		failure.count = 0
 	}
-	fe.count++
-	fe.lastFailure = now
+	failure.count++
+	failure.lastFailure = now
 
-	if fe.count >= p.MaxFailures {
-		if len(l.lockouts) >= l.lockoutsMax {
-			l.evictOneLockout()
+	if failure.count >= profile.MaxFailures {
+		if len(limiter.lockouts) >= limiter.lockoutsMax {
+			limiter.evictOneLockout()
 		}
-		l.lockouts[ip] = lockoutState{until: now.Add(p.LockoutDuration)}
-		delete(l.failures, ip)
-		l.metrics.RateLimitLockoutTotal.Inc()
-		l.logger.Warn("rate limit lockout",
+		limiter.lockouts[ip] = lockoutState{until: now.Add(profile.LockoutDuration)}
+		delete(limiter.failures, ip)
+		limiter.metrics.RateLimitLockoutTotal.Inc()
+		limiter.logger.Warn("rate limit lockout",
 			zap.String("ip", ip),
-			zap.String("profile", p.Name),
-			zap.Duration("lockout", p.LockoutDuration),
+			zap.String("profile", profile.Name),
+			zap.Duration("lockout", profile.LockoutDuration),
 		)
 		return
 	}
-	l.failures[ip] = fe
+	limiter.failures[ip] = failure
 }
 
 // Start runs the sweeper until ctx is cancelled. Intended to be launched in
-// a goroutine: `go l.Start(ctx, interval)`.
-func (l *Limiter) Start(ctx context.Context, sweepInterval time.Duration) {
+// a goroutine: `go limiter.Start(ctx, interval)`.
+func (limiter *Limiter) Start(ctx context.Context, sweepInterval time.Duration) {
 	if sweepInterval <= 0 {
 		sweepInterval = time.Minute
 	}
@@ -251,7 +251,7 @@ func (l *Limiter) Start(ctx context.Context, sweepInterval time.Duration) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			l.sweep()
+			limiter.sweep()
 		}
 	}
 }
@@ -259,15 +259,15 @@ func (l *Limiter) Start(ctx context.Context, sweepInterval time.Duration) {
 // staleCutoff is 2× the longest token-refill window across profiles.
 // Entries untouched past this age are safe to evict — any bucket they
 // backed has fully refilled, so recreating on next request is free.
-func (l *Limiter) staleCutoff() time.Duration {
+func (limiter *Limiter) staleCutoff() time.Duration {
 	var longest time.Duration
-	for _, p := range l.profiles {
-		if p.Rate <= 0 {
+	for _, profile := range limiter.profiles {
+		if profile.Rate <= 0 {
 			continue
 		}
-		w := time.Duration(float64(time.Second) * float64(p.Burst) / float64(p.Rate))
-		if w > longest {
-			longest = w
+		window := time.Duration(float64(time.Second) * float64(profile.Burst) / float64(profile.Rate))
+		if window > longest {
+			longest = window
 		}
 	}
 	if longest == 0 {
@@ -281,97 +281,97 @@ type staleKey struct {
 	key     string
 }
 
-func (l *Limiter) sweep() {
-	start := l.clock()
-	cutoffNanos := start.Add(-l.staleCutoff()).UnixNano()
+func (limiter *Limiter) sweep() {
+	start := limiter.clock()
+	cutoffNanos := start.Add(-limiter.staleCutoff()).UnixNano()
 
 	var ipStale, userStale []staleKey
 	var expiredLockouts, expiredFailures []string
 
-	l.mu.RLock()
-	for prof, m := range l.ipEntries {
-		for k, e := range m {
-			if e.lastSeen.Load() < cutoffNanos {
-				ipStale = append(ipStale, staleKey{prof, k})
+	limiter.mu.RLock()
+	for profileName, entries := range limiter.ipEntries {
+		for key, bucket := range entries {
+			if bucket.lastSeen.Load() < cutoffNanos {
+				ipStale = append(ipStale, staleKey{profileName, key})
 			}
 		}
 	}
-	for prof, m := range l.userEntries {
-		for k, e := range m {
-			if e.lastSeen.Load() < cutoffNanos {
-				userStale = append(userStale, staleKey{prof, k})
+	for profileName, entries := range limiter.userEntries {
+		for key, bucket := range entries {
+			if bucket.lastSeen.Load() < cutoffNanos {
+				userStale = append(userStale, staleKey{profileName, key})
 			}
 		}
 	}
-	for k, ls := range l.lockouts {
-		if !start.Before(ls.until) {
-			expiredLockouts = append(expiredLockouts, k)
+	for key, state := range limiter.lockouts {
+		if !start.Before(state.until) {
+			expiredLockouts = append(expiredLockouts, key)
 		}
 	}
 	failureCutoff := start.Add(-failureTTL)
-	for k, fe := range l.failures {
-		if fe.lastFailure.Before(failureCutoff) {
-			expiredFailures = append(expiredFailures, k)
+	for key, failure := range limiter.failures {
+		if failure.lastFailure.Before(failureCutoff) {
+			expiredFailures = append(expiredFailures, key)
 		}
 	}
-	l.mu.RUnlock()
+	limiter.mu.RUnlock()
 
-	l.deleteStale(ipStale, l.ipEntries, keyTypeIP)
-	l.deleteStale(userStale, l.userEntries, keyTypeUser)
+	limiter.deleteStale(ipStale, limiter.ipEntries, keyTypeIP)
+	limiter.deleteStale(userStale, limiter.userEntries, keyTypeUser)
 
 	if len(expiredLockouts) > 0 || len(expiredFailures) > 0 {
-		l.mu.Lock()
-		now := l.clock()
-		for _, k := range expiredLockouts {
-			if ls, ok := l.lockouts[k]; ok && !now.Before(ls.until) {
-				delete(l.lockouts, k)
+		limiter.mu.Lock()
+		now := limiter.clock()
+		for _, key := range expiredLockouts {
+			if state, ok := limiter.lockouts[key]; ok && !now.Before(state.until) {
+				delete(limiter.lockouts, key)
 			}
 		}
 		failureCutoff := now.Add(-failureTTL)
-		for _, k := range expiredFailures {
-			if fe, ok := l.failures[k]; ok && fe.lastFailure.Before(failureCutoff) {
-				delete(l.failures, k)
+		for _, key := range expiredFailures {
+			if failure, ok := limiter.failures[key]; ok && failure.lastFailure.Before(failureCutoff) {
+				delete(limiter.failures, key)
 			}
 		}
-		l.mu.Unlock()
+		limiter.mu.Unlock()
 	}
 
-	l.metrics.RateLimitSweepDurationSeconds.Observe(time.Since(start).Seconds())
+	limiter.metrics.RateLimitSweepDurationSeconds.Observe(time.Since(start).Seconds())
 }
 
-// deleteStale evicts the listed entries in batches of l.sweepBatch, releasing
+// deleteStale evicts the listed entries in batches of limiter.sweepBatch, releasing
 // the write lock between batches so concurrent readers can interleave.
-func (l *Limiter) deleteStale(keys []staleKey, target map[string]map[string]*entry, keyType string) {
+func (limiter *Limiter) deleteStale(keys []staleKey, target map[string]map[string]*entry, keyType string) {
 	if len(keys) == 0 {
 		return
 	}
-	for i := 0; i < len(keys); i += l.sweepBatch {
-		end := min(i+l.sweepBatch, len(keys))
-		batch := keys[i:end]
-		l.mu.Lock()
-		for _, sk := range batch {
-			delete(target[sk.profile], sk.key)
+	for idx := 0; idx < len(keys); idx += limiter.sweepBatch {
+		end := min(idx+limiter.sweepBatch, len(keys))
+		batch := keys[idx:end]
+		limiter.mu.Lock()
+		for _, stale := range batch {
+			delete(target[stale.profile], stale.key)
 		}
-		l.mu.Unlock()
-		for _, sk := range batch {
-			l.metrics.RateLimitEvictedTotal.WithLabelValues(sk.profile, keyType, evictReasonSweep).Inc()
+		limiter.mu.Unlock()
+		for _, stale := range batch {
+			limiter.metrics.RateLimitEvictedTotal.WithLabelValues(stale.profile, keyType, evictReasonSweep).Inc()
 		}
 	}
 }
 
 // evictOne picks a victim via sample-K LRU: sample up to sampleSize random
-// entries from m (Go's map iteration is randomized, so ranging gives us that),
+// entries from entries (Go's map iteration is randomized, so ranging gives us that),
 // and evict the one with the oldest lastSeen.
-// Caller MUST hold l.mu as writer.
-func (l *Limiter) evictOne(m map[string]*entry, profile, keyType string) {
+// Caller MUST hold limiter.mu as writer.
+func (limiter *Limiter) evictOne(entries map[string]*entry, profile, keyType string) {
 	var victim string
 	var oldest int64
 	sampled := 0
-	for k, e := range m {
-		ls := e.lastSeen.Load()
-		if sampled == 0 || ls < oldest {
-			victim = k
-			oldest = ls
+	for key, bucket := range entries {
+		lastSeen := bucket.lastSeen.Load()
+		if sampled == 0 || lastSeen < oldest {
+			victim = key
+			oldest = lastSeen
 		}
 		sampled++
 		if sampled >= sampleSize {
@@ -379,23 +379,23 @@ func (l *Limiter) evictOne(m map[string]*entry, profile, keyType string) {
 		}
 	}
 	if victim != "" {
-		delete(m, victim)
-		l.metrics.RateLimitEvictedTotal.WithLabelValues(profile, keyType, evictReasonCap).Inc()
+		delete(entries, victim)
+		limiter.metrics.RateLimitEvictedTotal.WithLabelValues(profile, keyType, evictReasonCap).Inc()
 	}
 }
 
 // evictOneLockout picks the lockout with the soonest-expiring `until` from a
 // sample — it was about to decay anyway. Random eviction would forgive an
 // active attacker with a lot of lockout time left.
-// Caller MUST hold l.mu as writer.
-func (l *Limiter) evictOneLockout() {
+// Caller MUST hold limiter.mu as writer.
+func (limiter *Limiter) evictOneLockout() {
 	var victim string
 	var soonest time.Time
 	sampled := 0
-	for k, ls := range l.lockouts {
-		if sampled == 0 || ls.until.Before(soonest) {
-			victim = k
-			soonest = ls.until
+	for key, state := range limiter.lockouts {
+		if sampled == 0 || state.until.Before(soonest) {
+			victim = key
+			soonest = state.until
 		}
 		sampled++
 		if sampled >= sampleSize {
@@ -403,6 +403,6 @@ func (l *Limiter) evictOneLockout() {
 		}
 	}
 	if victim != "" {
-		delete(l.lockouts, victim)
+		delete(limiter.lockouts, victim)
 	}
 }

--- a/internal/shared/ratelimit/limiter_test.go
+++ b/internal/shared/ratelimit/limiter_test.go
@@ -11,46 +11,46 @@ import (
 	"github.com/Shisa-Fosho/services/internal/shared/observability"
 )
 
-// fakeClock is a test clock whose Now() returns whatever t points at.
-type fakeClock struct{ t time.Time }
+// fakeClock is a test clock whose Now() returns the stored time.
+type fakeClock struct{ now time.Time }
 
-func (f *fakeClock) Now() time.Time          { return f.t }
-func (f *fakeClock) Advance(d time.Duration) { f.t = f.t.Add(d) }
+func (clock *fakeClock) Now() time.Time          { return clock.now }
+func (clock *fakeClock) Advance(d time.Duration) { clock.now = clock.now.Add(d) }
 
 func newTestLimiter(t *testing.T, profiles []Profile) (*Limiter, *fakeClock, *observability.Metrics) {
 	t.Helper()
-	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
-	m := observability.NewUnregisteredMetrics("test")
+	clk := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	metrics := observability.NewUnregisteredMetrics("test")
 	lim, err := NewLimiter(Config{
 		Profiles:       profiles,
 		Clock:          clk.Now,
-		Metrics:        m,
+		Metrics:        metrics,
 		Logger:         zaptest.NewLogger(t),
 		SweepBatchSize: 2,
 	})
 	if err != nil {
 		t.Fatalf("NewLimiter: %v", err)
 	}
-	return lim, clk, m
+	return lim, clk, metrics
 }
 
 func TestAllowIP_WithinBurstPasses(t *testing.T) {
 	t.Parallel()
-	p := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 3}
-	lim, _, _ := newTestLimiter(t, []Profile{p})
+	profile := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 3}
+	lim, _, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("default")
-	for i := 0; i < 3; i++ {
+	for idx := 0; idx < 3; idx++ {
 		ok, _ := lim.AllowIP(prof, "1.2.3.4")
 		if !ok {
-			t.Fatalf("request %d: expected allow within burst", i+1)
+			t.Fatalf("request %d: expected allow within burst", idx+1)
 		}
 	}
 }
 
 func TestAllowIP_OverBudgetRejects(t *testing.T) {
 	t.Parallel()
-	p := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 2}
-	lim, _, _ := newTestLimiter(t, []Profile{p})
+	profile := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 2}
+	lim, _, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("default")
 	lim.AllowIP(prof, "1.2.3.4")
 	lim.AllowIP(prof, "1.2.3.4")
@@ -65,8 +65,8 @@ func TestAllowIP_OverBudgetRejects(t *testing.T) {
 
 func TestAllowIP_TokenRefillsOverTime(t *testing.T) {
 	t.Parallel()
-	p := Profile{Name: "default", Rate: rate.Every(100 * time.Millisecond), Burst: 1}
-	lim, clk, _ := newTestLimiter(t, []Profile{p})
+	profile := Profile{Name: "default", Rate: rate.Every(100 * time.Millisecond), Burst: 1}
+	lim, clk, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("default")
 	if ok, _ := lim.AllowIP(prof, "1.2.3.4"); !ok {
 		t.Fatal("first request should pass")
@@ -82,8 +82,8 @@ func TestAllowIP_TokenRefillsOverTime(t *testing.T) {
 
 func TestAllowIP_DifferentKeysIndependent(t *testing.T) {
 	t.Parallel()
-	p := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 1}
-	lim, _, _ := newTestLimiter(t, []Profile{p})
+	profile := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 1}
+	lim, _, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("default")
 	lim.AllowIP(prof, "1.1.1.1")
 	if ok, _ := lim.AllowIP(prof, "2.2.2.2"); !ok {
@@ -93,14 +93,14 @@ func TestAllowIP_DifferentKeysIndependent(t *testing.T) {
 
 func TestRecordAuthFailure_LocksAfterN(t *testing.T) {
 	t.Parallel()
-	p := Profile{
+	profile := Profile{
 		Name:            "auth",
 		Rate:            rate.Every(time.Second),
 		Burst:           10,
 		MaxFailures:     3,
 		LockoutDuration: 15 * time.Minute,
 	}
-	lim, _, _ := newTestLimiter(t, []Profile{p})
+	lim, _, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("auth")
 
 	if locked, _ := lim.IsLockedOut("1.2.3.4"); locked {
@@ -123,14 +123,14 @@ func TestRecordAuthFailure_LocksAfterN(t *testing.T) {
 
 func TestRecordAuthFailure_LockoutExpires(t *testing.T) {
 	t.Parallel()
-	p := Profile{
+	profile := Profile{
 		Name:            "auth",
 		Rate:            rate.Every(time.Second),
 		Burst:           10,
 		MaxFailures:     1,
 		LockoutDuration: time.Minute,
 	}
-	lim, clk, _ := newTestLimiter(t, []Profile{p})
+	lim, clk, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("auth")
 	lim.RecordAuthFailure("1.2.3.4", prof)
 	if locked, _ := lim.IsLockedOut("1.2.3.4"); !locked {
@@ -144,10 +144,10 @@ func TestRecordAuthFailure_LockoutExpires(t *testing.T) {
 
 func TestRecordAuthFailure_NoLockoutForZeroConfig(t *testing.T) {
 	t.Parallel()
-	p := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 10} // MaxFailures=0
-	lim, _, _ := newTestLimiter(t, []Profile{p})
+	profile := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 10} // MaxFailures=0
+	lim, _, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("default")
-	for i := 0; i < 100; i++ {
+	for idx := 0; idx < 100; idx++ {
 		lim.RecordAuthFailure("1.2.3.4", prof)
 	}
 	if locked, _ := lim.IsLockedOut("1.2.3.4"); locked {
@@ -157,8 +157,8 @@ func TestRecordAuthFailure_NoLockoutForZeroConfig(t *testing.T) {
 
 func TestAllowIP_CapEvictsOldestFromSample(t *testing.T) {
 	t.Parallel()
-	p := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 1, MaxEntries: 3}
-	lim, clk, m := newTestLimiter(t, []Profile{p})
+	profile := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 1, MaxEntries: 3}
+	lim, clk, metrics := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("default")
 	// Fill to cap, each with a distinct lastSeen.
 	lim.AllowIP(prof, "a")
@@ -169,7 +169,7 @@ func TestAllowIP_CapEvictsOldestFromSample(t *testing.T) {
 	clk.Advance(time.Second)
 	// 4th insertion triggers eviction.
 	lim.AllowIP(prof, "d")
-	if got := testCounterValue(t, m.RateLimitEvictedTotal.WithLabelValues("default", "ip", "cap")); got != 1 {
+	if got := testCounterValue(t, metrics.RateLimitEvictedTotal.WithLabelValues("default", "ip", "cap")); got != 1 {
 		t.Fatalf("cap eviction counter = %v, want 1", got)
 	}
 	if got := len(lim.ipEntries["default"]); got != 3 {
@@ -179,8 +179,8 @@ func TestAllowIP_CapEvictsOldestFromSample(t *testing.T) {
 
 func TestSweep_EvictsStaleEntries(t *testing.T) {
 	t.Parallel()
-	p := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 5}
-	lim, clk, m := newTestLimiter(t, []Profile{p})
+	profile := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 5}
+	lim, clk, metrics := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("default")
 	lim.AllowIP(prof, "stale")
 	// Advance well past 2× refill window (5s × 2 = 10s).
@@ -193,21 +193,21 @@ func TestSweep_EvictsStaleEntries(t *testing.T) {
 	if _, ok := lim.ipEntries["default"]["fresh"]; !ok {
 		t.Fatal("fresh key should survive")
 	}
-	if got := testCounterValue(t, m.RateLimitEvictedTotal.WithLabelValues("default", "ip", "sweep")); got != 1 {
+	if got := testCounterValue(t, metrics.RateLimitEvictedTotal.WithLabelValues("default", "ip", "sweep")); got != 1 {
 		t.Fatalf("sweep eviction counter = %v, want 1", got)
 	}
 }
 
 func TestSweep_ExpiredLockoutsRemoved(t *testing.T) {
 	t.Parallel()
-	p := Profile{
+	profile := Profile{
 		Name:            "auth",
 		Rate:            rate.Every(time.Second),
 		Burst:           5,
 		MaxFailures:     1,
 		LockoutDuration: time.Minute,
 	}
-	lim, clk, _ := newTestLimiter(t, []Profile{p})
+	lim, clk, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("auth")
 	lim.RecordAuthFailure("1.1.1.1", prof)
 	clk.Advance(2 * time.Minute)
@@ -219,14 +219,14 @@ func TestSweep_ExpiredLockoutsRemoved(t *testing.T) {
 
 func TestSweep_ExpiresFailuresBelowThreshold(t *testing.T) {
 	t.Parallel()
-	p := Profile{
+	profile := Profile{
 		Name:            "auth",
 		Rate:            rate.Every(time.Second),
 		Burst:           5,
 		MaxFailures:     5,
 		LockoutDuration: time.Minute,
 	}
-	lim, clk, _ := newTestLimiter(t, []Profile{p})
+	lim, clk, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("auth")
 	lim.RecordAuthFailure("1.1.1.1", prof)
 	lim.RecordAuthFailure("1.1.1.1", prof)
@@ -242,14 +242,14 @@ func TestSweep_ExpiresFailuresBelowThreshold(t *testing.T) {
 
 func TestRecordAuthFailure_StaleCountResets(t *testing.T) {
 	t.Parallel()
-	p := Profile{
+	profile := Profile{
 		Name:            "auth",
 		Rate:            rate.Every(time.Second),
 		Burst:           10,
 		MaxFailures:     3,
 		LockoutDuration: time.Minute,
 	}
-	lim, clk, _ := newTestLimiter(t, []Profile{p})
+	lim, clk, _ := newTestLimiter(t, []Profile{profile})
 	prof, _ := lim.Profile("auth")
 	lim.RecordAuthFailure("1.1.1.1", prof)
 	lim.RecordAuthFailure("1.1.1.1", prof)
@@ -263,8 +263,8 @@ func TestRecordAuthFailure_StaleCountResets(t *testing.T) {
 
 func TestStart_ExitsOnContextCancel(t *testing.T) {
 	t.Parallel()
-	p := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 1}
-	lim, _, _ := newTestLimiter(t, []Profile{p})
+	profile := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 1}
+	lim, _, _ := newTestLimiter(t, []Profile{profile})
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { lim.Start(ctx, 10*time.Millisecond); close(done) }()

--- a/internal/shared/ratelimit/middleware.go
+++ b/internal/shared/ratelimit/middleware.go
@@ -32,23 +32,23 @@ const (
 // Middleware returns an HTTP middleware enforcing the named profile.
 // Panics at registration time if profileName is unknown — this is a
 // programmer error and should surface immediately.
-func (l *Limiter) Middleware(profileName string, keyBy KeyStrategy) func(http.Handler) http.Handler {
-	p, ok := l.profiles[profileName]
+func (limiter *Limiter) Middleware(profileName string, keyBy KeyStrategy) func(http.Handler) http.Handler {
+	profile, ok := limiter.profiles[profileName]
 	if !ok {
 		panic(fmt.Sprintf("ratelimit: unknown profile %q", profileName))
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip := ClientIP(r, l.trustProxy)
-			if p.MaxFailures > 0 {
-				if locked, remaining := l.IsLockedOut(ip); locked {
-					l.reject(w, r, p, keyTypeIP, remaining)
+			ip := ClientIP(r, limiter.trustProxy)
+			if profile.MaxFailures > 0 {
+				if locked, remaining := limiter.IsLockedOut(ip); locked {
+					limiter.reject(w, r, profile, keyTypeIP, remaining)
 					return
 				}
 			}
-			allowed, retryAfter, keyType := l.applyProfile(r, p, keyBy, ip)
+			allowed, retryAfter, keyType := limiter.applyProfile(r, profile, keyBy, ip)
 			if !allowed {
-				l.reject(w, r, p, keyType, retryAfter)
+				limiter.reject(w, r, profile, keyType, retryAfter)
 				return
 			}
 			next.ServeHTTP(w, r)
@@ -56,34 +56,34 @@ func (l *Limiter) Middleware(profileName string, keyBy KeyStrategy) func(http.Ha
 	}
 }
 
-func (l *Limiter) applyProfile(r *http.Request, p *Profile, keyBy KeyStrategy, ip string) (bool, time.Duration, string) {
+func (limiter *Limiter) applyProfile(r *http.Request, profile *Profile, keyBy KeyStrategy, ip string) (bool, time.Duration, string) {
 	if keyBy == KeyByUser {
-		if user := l.extractUser(r); user != "" {
-			ok, ra := l.AllowUser(p, user)
-			return ok, ra, keyTypeUser
+		if user := limiter.extractUser(r); user != "" {
+			ok, retryAfter := limiter.AllowUser(profile, user)
+			return ok, retryAfter, keyTypeUser
 		}
 	}
-	ok, ra := l.AllowIP(p, ip)
-	return ok, ra, keyTypeIP
+	ok, retryAfter := limiter.AllowIP(profile, ip)
+	return ok, retryAfter, keyTypeIP
 }
 
-func (l *Limiter) extractUser(r *http.Request) string {
-	if l.userExtractor == nil {
+func (limiter *Limiter) extractUser(r *http.Request) string {
+	if limiter.userExtractor == nil {
 		return ""
 	}
-	return l.userExtractor(r.Context())
+	return limiter.userExtractor(r.Context())
 }
 
-func (l *Limiter) reject(w http.ResponseWriter, r *http.Request, p *Profile, keyType string, retryAfter time.Duration) {
+func (limiter *Limiter) reject(w http.ResponseWriter, r *http.Request, profile *Profile, keyType string, retryAfter time.Duration) {
 	seconds := int(math.Ceil(retryAfter.Seconds()))
 	if seconds < 1 {
 		seconds = 1
 	}
 	w.Header().Set("Retry-After", strconv.Itoa(seconds))
-	l.metrics.RateLimitRejectedTotal.WithLabelValues(p.Name, keyType).Inc()
-	l.logger.Debug("rate limit rejected",
+	limiter.metrics.RateLimitRejectedTotal.WithLabelValues(profile.Name, keyType).Inc()
+	limiter.logger.Debug("rate limit rejected",
 		zap.String("request_id", observability.RequestIDFrom(r.Context())),
-		zap.String("profile", p.Name),
+		zap.String("profile", profile.Name),
 		zap.String("key_type", keyType),
 		zap.Int("retry_after_seconds", seconds),
 	)
@@ -97,21 +97,21 @@ func (l *Limiter) reject(w http.ResponseWriter, r *http.Request, p *Profile, key
 //
 // Exported so services can key auth-failure callbacks on the same IP the
 // middleware used.
-func ClientIP(r *http.Request, trustProxy bool) string {
+func ClientIP(request *http.Request, trustProxy bool) string {
 	if trustProxy {
-		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			if i := strings.IndexByte(xff, ','); i >= 0 {
-				return strings.TrimSpace(xff[:i])
+		if xff := request.Header.Get("X-Forwarded-For"); xff != "" {
+			if idx := strings.IndexByte(xff, ','); idx >= 0 {
+				return strings.TrimSpace(xff[:idx])
 			}
 			return strings.TrimSpace(xff)
 		}
-		if xr := r.Header.Get("X-Real-IP"); xr != "" {
-			return strings.TrimSpace(xr)
+		if realIP := request.Header.Get("X-Real-IP"); realIP != "" {
+			return strings.TrimSpace(realIP)
 		}
 	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	host, _, err := net.SplitHostPort(request.RemoteAddr)
 	if err != nil {
-		return r.RemoteAddr
+		return request.RemoteAddr
 	}
 	return host
 }

--- a/internal/shared/ratelimit/middleware_test.go
+++ b/internal/shared/ratelimit/middleware_test.go
@@ -17,15 +17,15 @@ import (
 type userCtxKey struct{}
 
 func userExtractor(ctx context.Context) string {
-	v, _ := ctx.Value(userCtxKey{}).(string)
-	return v
+	val, _ := ctx.Value(userCtxKey{}).(string)
+	return val
 }
 
-func newMwLimiter(t *testing.T, p Profile, extractor func(context.Context) string, trustProxy bool) (*Limiter, *fakeClock) {
+func newMwLimiter(t *testing.T, profile Profile, extractor func(context.Context) string, trustProxy bool) (*Limiter, *fakeClock) {
 	t.Helper()
-	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	clk := &fakeClock{now: time.Unix(1_700_000_000, 0)}
 	lim, err := NewLimiter(Config{
-		Profiles:          []Profile{p},
+		Profiles:          []Profile{profile},
 		Clock:             clk.Now,
 		UserExtractor:     extractor,
 		TrustProxyHeaders: trustProxy,
@@ -45,37 +45,37 @@ func okHandler() http.Handler {
 func TestMiddleware_HappyPath(t *testing.T) {
 	t.Parallel()
 	lim, _ := newMwLimiter(t, Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 3}, nil, false)
-	h := lim.Middleware("default", KeyByIP)(okHandler())
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.RemoteAddr = "1.2.3.4:5555"
-	h.ServeHTTP(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", w.Code)
+	handler := lim.Middleware("default", KeyByIP)(okHandler())
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "1.2.3.4:5555"
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
 	}
 }
 
 func TestMiddleware_Returns429WithRetryAfter(t *testing.T) {
 	t.Parallel()
 	lim, _ := newMwLimiter(t, Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 1}, nil, false)
-	h := lim.Middleware("default", KeyByIP)(okHandler())
+	handler := lim.Middleware("default", KeyByIP)(okHandler())
 
 	// First request consumes the burst.
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.RemoteAddr = "1.2.3.4:5555"
-	h.ServeHTTP(httptest.NewRecorder(), r)
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "1.2.3.4:5555"
+	handler.ServeHTTP(httptest.NewRecorder(), request)
 
 	// Second request should be rejected.
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, r)
-	if w.Code != http.StatusTooManyRequests {
-		t.Fatalf("status = %d, want 429", w.Code)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", recorder.Code)
 	}
-	if ra := w.Header().Get("Retry-After"); ra == "" {
+	if retryAfter := recorder.Header().Get("Retry-After"); retryAfter == "" {
 		t.Fatal("expected Retry-After header")
 	}
 	var body map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decoding body: %v", err)
 	}
 	if body["error"] == "" {
@@ -85,29 +85,29 @@ func TestMiddleware_Returns429WithRetryAfter(t *testing.T) {
 
 func TestMiddleware_LockoutShortCircuits(t *testing.T) {
 	t.Parallel()
-	p := Profile{
+	profile := Profile{
 		Name:            "auth",
 		Rate:            rate.Every(time.Second),
 		Burst:           100, // generous so rate limit doesn't fire
 		MaxFailures:     2,
 		LockoutDuration: time.Hour,
 	}
-	lim, _ := newMwLimiter(t, p, nil, false)
+	lim, _ := newMwLimiter(t, profile, nil, false)
 	prof, _ := lim.Profile("auth")
 	lim.RecordAuthFailure("1.2.3.4", prof)
 	lim.RecordAuthFailure("1.2.3.4", prof)
 
 	called := false
-	h := lim.Middleware("auth", KeyByIP)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := lim.Middleware("auth", KeyByIP)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	}))
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
-	r.RemoteAddr = "1.2.3.4:5555"
-	h.ServeHTTP(w, r)
-	if w.Code != http.StatusTooManyRequests {
-		t.Fatalf("status = %d, want 429", w.Code)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+	request.RemoteAddr = "1.2.3.4:5555"
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", recorder.Code)
 	}
 	if called {
 		t.Fatal("handler should not be invoked when locked out")
@@ -116,30 +116,30 @@ func TestMiddleware_LockoutShortCircuits(t *testing.T) {
 
 func TestMiddleware_KeyByUserFallsBackToIP(t *testing.T) {
 	t.Parallel()
-	p := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 1}
-	lim, _ := newMwLimiter(t, p, userExtractor, false)
-	h := lim.Middleware("default", KeyByUser)(okHandler())
+	profile := Profile{Name: "default", Rate: rate.Every(time.Second), Burst: 1}
+	lim, _ := newMwLimiter(t, profile, userExtractor, false)
+	handler := lim.Middleware("default", KeyByUser)(okHandler())
 
 	// No user in context — should key on IP.
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.RemoteAddr = "1.2.3.4:5555"
-	h.ServeHTTP(httptest.NewRecorder(), r)
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "1.2.3.4:5555"
+	handler.ServeHTTP(httptest.NewRecorder(), request)
 
 	// Second request from same IP, still no user — should 429.
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, r)
-	if w.Code != http.StatusTooManyRequests {
-		t.Fatalf("status = %d, want 429 (IP-keyed)", w.Code)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (IP-keyed)", recorder.Code)
 	}
 
 	// Different user on same IP — different bucket, should pass.
-	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
-	r2.RemoteAddr = "1.2.3.4:5555"
-	r2 = r2.WithContext(context.WithValue(context.Background(), userCtxKey{}, "alice"))
-	w2 := httptest.NewRecorder()
-	h.ServeHTTP(w2, r2)
-	if w2.Code != http.StatusOK {
-		t.Fatalf("user-keyed status = %d, want 200", w2.Code)
+	userRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	userRequest.RemoteAddr = "1.2.3.4:5555"
+	userRequest = userRequest.WithContext(context.WithValue(context.Background(), userCtxKey{}, "alice"))
+	userRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(userRecorder, userRequest)
+	if userRecorder.Code != http.StatusOK {
+		t.Fatalf("user-keyed status = %d, want 200", userRecorder.Code)
 	}
 }
 
@@ -168,18 +168,18 @@ func TestClientIPExported_ProxyHeaderRespectsTrust(t *testing.T) {
 		{"remoteaddr fallback when XFF empty", true, "", "192.0.2.1:1234", "192.0.2.1"},
 		{"bare remoteaddr without port", false, "", "192.0.2.1", "192.0.2.1"},
 	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			r := httptest.NewRequest(http.MethodGet, "/", nil)
-			r.RemoteAddr = tc.remote
-			if tc.xff != "" {
-				r.Header.Set("X-Forwarded-For", tc.xff)
+			request := httptest.NewRequest(http.MethodGet, "/", nil)
+			request.RemoteAddr = testCase.remote
+			if testCase.xff != "" {
+				request.Header.Set("X-Forwarded-For", testCase.xff)
 			}
-			got := ClientIP(r, tc.trust)
-			if got != tc.want {
-				t.Errorf("clientIP = %q, want %q", got, tc.want)
+			got := ClientIP(request, testCase.trust)
+			if got != testCase.want {
+				t.Errorf("clientIP = %q, want %q", got, testCase.want)
 			}
 		})
 	}

--- a/internal/trading/auth/apikey_test.go
+++ b/internal/trading/auth/apikey_test.go
@@ -16,8 +16,8 @@ func TestDeriveAPIKey_Deterministic(t *testing.T) {
 	t.Parallel()
 
 	sig := make([]byte, 65)
-	for i := range sig {
-		sig[i] = byte(i)
+	for idx := range sig {
+		sig[idx] = byte(idx)
 	}
 
 	key1, secret1, pass1 := DeriveAPIKey(testDerivationSecret, sig)
@@ -113,15 +113,15 @@ func TestDeriveAPIKey_KeyAndSecretDiffer(t *testing.T) {
 func TestHashAPIKey_Consistency(t *testing.T) {
 	t.Parallel()
 
-	h1 := HashAPIKey("test-key-123")
-	h2 := HashAPIKey("test-key-123")
+	hash1 := HashAPIKey("test-key-123")
+	hash2 := HashAPIKey("test-key-123")
 
-	if h1 != h2 {
-		t.Errorf("hashes differ: %q vs %q", h1, h2)
+	if hash1 != hash2 {
+		t.Errorf("hashes differ: %q vs %q", hash1, hash2)
 	}
 
-	if len(h1) != 64 {
-		t.Errorf("hash length = %d, want 64", len(h1))
+	if len(hash1) != 64 {
+		t.Errorf("hash length = %d, want 64", len(hash1))
 	}
 }
 
@@ -159,12 +159,12 @@ func TestEncryptSecret_DifferentNonces(t *testing.T) {
 // eip712Hash builds the EIP-712 hash for a ClobAuth message (test helper).
 func eip712Hash(t *testing.T, address string) []byte {
 	t.Helper()
-	td := clobAuthTypedData(address, "1700000000", "0", ClobAuthMessage, 137)
-	domainHash, err := td.HashStruct("EIP712Domain", td.Domain.Map())
+	typedData := clobAuthTypedData(address, "1700000000", "0", ClobAuthMessage, 137)
+	domainHash, err := typedData.HashStruct("EIP712Domain", typedData.Domain.Map())
 	if err != nil {
 		t.Fatalf("hashing domain: %v", err)
 	}
-	messageHash, err := td.HashStruct(td.PrimaryType, td.Message)
+	messageHash, err := typedData.HashStruct(typedData.PrimaryType, typedData.Message)
 	if err != nil {
 		t.Fatalf("hashing message: %v", err)
 	}

--- a/internal/trading/auth/handler.go
+++ b/internal/trading/auth/handler.go
@@ -33,22 +33,22 @@ type HandlerOption func(*Handler)
 // WithHandlerAuthFailureHook sets a callback invoked on EIP-712 sig
 // verification failure inside /auth/derive-api-key. Used to drive rate-limiter
 // lockout. Not invoked on shape errors (missing required headers).
-func WithHandlerAuthFailureHook(fn func(*http.Request)) HandlerOption {
-	return func(h *Handler) { h.onAuthFailure = fn }
+func WithHandlerAuthFailureHook(hook func(*http.Request)) HandlerOption {
+	return func(handler *Handler) { handler.onAuthFailure = hook }
 }
 
 // NewHandler creates an API-key handler.
 func NewHandler(logger *zap.Logger, repo APIKeyRepository, apiKeyCfg APIKeyConfig, opts ...HandlerOption) *Handler {
-	h := &Handler{
+	handler := &Handler{
 		logger:    logger,
 		repo:      repo,
 		encKey:    apiKeyCfg.EncryptionKey,
 		apiKeyCfg: apiKeyCfg,
 	}
-	for _, fn := range opts {
-		fn(h)
+	for _, option := range opts {
+		option(handler)
 	}
-	return h
+	return handler
 }
 
 // RegisterRoutes registers the three API-key lifecycle endpoints on the mux.
@@ -59,32 +59,32 @@ func NewHandler(logger *zap.Logger, repo APIKeyRepository, apiKeyCfg APIKeyConfi
 // Auth-wise:
 //   - derive is L1-authenticated (EIP-712 wallet sig) — the handler verifies.
 //   - list and revoke are L2-authenticated (HMAC) — wrapped in AuthenticateAPIKey.
-func (h *Handler) RegisterRoutes(mux *http.ServeMux, authWrapper func(http.Handler) http.Handler) {
+func (handler *Handler) RegisterRoutes(mux *http.ServeMux, authWrapper func(http.Handler) http.Handler) {
 	hmacOpts := []MiddlewareOption{}
-	if h.onAuthFailure != nil {
-		hmacOpts = append(hmacOpts, WithAuthFailureHook(h.onAuthFailure))
+	if handler.onAuthFailure != nil {
+		hmacOpts = append(hmacOpts, WithAuthFailureHook(handler.onAuthFailure))
 	}
 
-	derive := wrap(authWrapper, http.HandlerFunc(h.deriveAPIKey))
-	list := wrap(authWrapper, AuthenticateAPIKey(h.repo, h.encKey, h.logger, hmacOpts...)(http.HandlerFunc(h.listAPIKeys)))
-	revoke := wrap(authWrapper, AuthenticateAPIKey(h.repo, h.encKey, h.logger, hmacOpts...)(http.HandlerFunc(h.revokeAPIKey)))
+	derive := wrap(authWrapper, http.HandlerFunc(handler.deriveAPIKey))
+	list := wrap(authWrapper, AuthenticateAPIKey(handler.repo, handler.encKey, handler.logger, hmacOpts...)(http.HandlerFunc(handler.listAPIKeys)))
+	revoke := wrap(authWrapper, AuthenticateAPIKey(handler.repo, handler.encKey, handler.logger, hmacOpts...)(http.HandlerFunc(handler.revokeAPIKey)))
 
 	mux.Handle("GET /auth/derive-api-key", derive)
 	mux.Handle("GET /auth/api-keys", list)
 	mux.Handle("DELETE /auth/api-key", revoke)
 }
 
-// wrap applies mw to h if mw is non-nil, otherwise returns h unchanged.
-func wrap(mw func(http.Handler) http.Handler, h http.Handler) http.Handler {
+// wrap applies mw to inner if mw is non-nil, otherwise returns inner unchanged.
+func wrap(mw func(http.Handler) http.Handler, inner http.Handler) http.Handler {
 	if mw == nil {
-		return h
+		return inner
 	}
-	return mw(h)
+	return mw(inner)
 }
 
-func (h *Handler) recordAuthFailure(r *http.Request) {
-	if h.onAuthFailure != nil {
-		h.onAuthFailure(r)
+func (handler *Handler) recordAuthFailure(r *http.Request) {
+	if handler.onAuthFailure != nil {
+		handler.onAuthFailure(r)
 	}
 }
 
@@ -108,7 +108,7 @@ type deriveAPIKeyResponse struct {
 // The signature itself proves wallet control, so this endpoint is NOT wrapped
 // in any middleware — anyone able to produce a valid EIP-712 sig for address X
 // is, by definition, the owner of X.
-func (h *Handler) deriveAPIKey(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) deriveAPIKey(w http.ResponseWriter, r *http.Request) {
 	address := r.Header.Get(HeaderAddress)
 	signature := r.Header.Get(HeaderSignature)
 	timestamp := r.Header.Get(HeaderTimestamp)
@@ -122,31 +122,31 @@ func (h *Handler) deriveAPIKey(w http.ResponseWriter, r *http.Request) {
 		nonce = "0" // SDK default: createL1Headers sends "0" when nonce is unset.
 	}
 
-	sigBytes, err := VerifyEIP712Signature(address, timestamp, nonce, ClobAuthMessage, signature, h.apiKeyCfg.ChainID)
+	sigBytes, err := VerifyEIP712Signature(address, timestamp, nonce, ClobAuthMessage, signature, handler.apiKeyCfg.ChainID)
 	if err != nil {
-		h.logger.Info("EIP-712 verification failed", zap.String("address", address), zap.Error(err))
-		h.recordAuthFailure(r)
+		handler.logger.Info("EIP-712 verification failed", zap.String("address", address), zap.Error(err))
+		handler.recordAuthFailure(r)
 		httputil.ErrorResponse(w, http.StatusUnauthorized, "signature verification failed")
 		return
 	}
 
-	apiKey, hmacSecret, passphrase := DeriveAPIKey(h.apiKeyCfg.DerivationSecret, sigBytes)
+	apiKey, hmacSecret, passphrase := DeriveAPIKey(handler.apiKeyCfg.DerivationSecret, sigBytes)
 	keyHash := HashAPIKey(apiKey)
 
-	encryptedSecret, err := EncryptSecret(h.apiKeyCfg.EncryptionKey, hmacSecret)
+	encryptedSecret, err := EncryptSecret(handler.apiKeyCfg.EncryptionKey, hmacSecret)
 	if err != nil {
-		h.internalError(w, "encrypting HMAC secret", err)
+		handler.internalError(w, "encrypting HMAC secret", err)
 		return
 	}
 
-	if err := h.repo.UpsertAPIKey(r.Context(), &APIKey{
+	if err := handler.repo.UpsertAPIKey(r.Context(), &APIKey{
 		KeyHash:             keyHash,
 		UserAddress:         address,
 		HMACSecretEncrypted: encryptedSecret,
 		PassphraseHash:      HashAPIKey(passphrase),
 		ExpiresAt:           time.Now().Add(apiKeyTTL),
 	}); err != nil {
-		h.internalError(w, "upserting api key", err)
+		handler.internalError(w, "upserting api key", err)
 		return
 	}
 
@@ -160,7 +160,7 @@ func (h *Handler) deriveAPIKey(w http.ResponseWriter, r *http.Request) {
 // revokeAPIKey implements DELETE /auth/api-key. Auth is L2 HMAC; user address
 // is extracted from context (set by AuthenticateAPIKey middleware). The
 // request body carries the api_key whose hash we should mark revoked.
-func (h *Handler) revokeAPIKey(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) revokeAPIKey(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		APIKey string `json:"api_key"`
 	}
@@ -176,12 +176,12 @@ func (h *Handler) revokeAPIKey(w http.ResponseWriter, r *http.Request) {
 	address := UserAddressFrom(r.Context())
 	keyHash := HashAPIKey(req.APIKey)
 
-	if err := h.repo.RevokeAPIKey(r.Context(), keyHash, address); err != nil {
+	if err := handler.repo.RevokeAPIKey(r.Context(), keyHash, address); err != nil {
 		if errors.Is(err, data.ErrNotFound) {
 			httputil.ErrorResponse(w, http.StatusNotFound, "api key not found")
 			return
 		}
-		h.internalError(w, "revoking api key", err)
+		handler.internalError(w, "revoking api key", err)
 		return
 	}
 
@@ -199,29 +199,29 @@ type apiKeyListItem struct {
 
 // listAPIKeys implements GET /auth/api-keys. Auth is L2 HMAC; user address is
 // extracted from context.
-func (h *Handler) listAPIKeys(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) listAPIKeys(w http.ResponseWriter, r *http.Request) {
 	address := UserAddressFrom(r.Context())
 
-	keys, err := h.repo.GetAPIKeysByUser(r.Context(), address)
+	keys, err := handler.repo.GetAPIKeysByUser(r.Context(), address)
 	if err != nil {
-		h.internalError(w, "listing api keys", err)
+		handler.internalError(w, "listing api keys", err)
 		return
 	}
 
 	items := make([]apiKeyListItem, len(keys))
-	for i, k := range keys {
-		items[i] = apiKeyListItem{
-			KeyHash:   k.KeyHash,
-			Label:     k.Label,
-			ExpiresAt: k.ExpiresAt,
-			CreatedAt: k.CreatedAt,
+	for idx, key := range keys {
+		items[idx] = apiKeyListItem{
+			KeyHash:   key.KeyHash,
+			Label:     key.Label,
+			ExpiresAt: key.ExpiresAt,
+			CreatedAt: key.CreatedAt,
 		}
 	}
 
 	_ = httputil.EncodeJSON(w, http.StatusOK, items)
 }
 
-func (h *Handler) internalError(w http.ResponseWriter, msg string, err error) {
-	h.logger.Error(msg, zap.Error(err))
+func (handler *Handler) internalError(w http.ResponseWriter, msg string, err error) {
+	handler.logger.Error(msg, zap.Error(err))
 	httputil.ErrorResponse(w, http.StatusInternalServerError, "internal server error")
 }

--- a/internal/trading/auth/handler_test.go
+++ b/internal/trading/auth/handler_test.go
@@ -30,35 +30,35 @@ func newFakeRepo() *fakeRepo {
 	return &fakeRepo{apiKeys: make(map[string]*APIKey)}
 }
 
-func (r *fakeRepo) UpsertAPIKey(_ context.Context, key *APIKey) error {
-	r.apiKeys[key.KeyHash] = key
+func (repo *fakeRepo) UpsertAPIKey(_ context.Context, key *APIKey) error {
+	repo.apiKeys[key.KeyHash] = key
 	return nil
 }
 
-func (r *fakeRepo) GetAPIKeyByHash(_ context.Context, keyHash string) (*APIKey, error) {
-	k, ok := r.apiKeys[keyHash]
-	if !ok || k.Revoked || k.ExpiresAt.Before(time.Now()) {
+func (repo *fakeRepo) GetAPIKeyByHash(_ context.Context, keyHash string) (*APIKey, error) {
+	key, ok := repo.apiKeys[keyHash]
+	if !ok || key.Revoked || key.ExpiresAt.Before(time.Now()) {
 		return nil, data.ErrNotFound
 	}
-	return k, nil
+	return key, nil
 }
 
-func (r *fakeRepo) GetAPIKeysByUser(_ context.Context, userAddress string) ([]*APIKey, error) {
+func (repo *fakeRepo) GetAPIKeysByUser(_ context.Context, userAddress string) ([]*APIKey, error) {
 	var result []*APIKey
-	for _, k := range r.apiKeys {
-		if k.UserAddress == userAddress && !k.Revoked {
-			result = append(result, k)
+	for _, key := range repo.apiKeys {
+		if key.UserAddress == userAddress && !key.Revoked {
+			result = append(result, key)
 		}
 	}
 	return result, nil
 }
 
-func (r *fakeRepo) RevokeAPIKey(_ context.Context, keyHash string, userAddress string) error {
-	k, ok := r.apiKeys[keyHash]
-	if !ok || k.UserAddress != userAddress || k.Revoked {
+func (repo *fakeRepo) RevokeAPIKey(_ context.Context, keyHash string, userAddress string) error {
+	key, ok := repo.apiKeys[keyHash]
+	if !ok || key.UserAddress != userAddress || key.Revoked {
 		return data.ErrNotFound
 	}
-	k.Revoked = true
+	key.Revoked = true
 	return nil
 }
 
@@ -98,19 +98,19 @@ func signedEIP712(t *testing.T) (address string, sigHex string) {
 // the SDK's createL1Headers function would populate.
 func l1Request(t *testing.T, address, sigHex, timestamp, nonce string) *http.Request {
 	t.Helper()
-	r := httptest.NewRequest(http.MethodGet, "/auth/derive-api-key", nil)
-	r.Header.Set(HeaderAddress, address)
-	r.Header.Set(HeaderSignature, sigHex)
-	r.Header.Set(HeaderTimestamp, timestamp)
-	r.Header.Set(HeaderNonce, nonce)
-	return r
+	request := httptest.NewRequest(http.MethodGet, "/auth/derive-api-key", nil)
+	request.Header.Set(HeaderAddress, address)
+	request.Header.Set(HeaderSignature, sigHex)
+	request.Header.Set(HeaderTimestamp, timestamp)
+	request.Header.Set(HeaderNonce, nonce)
+	return request
 }
 
 // keysOf lists map keys for readable assertion errors.
 func keysOf(m map[string]interface{}) []string {
 	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
+	for key := range m {
+		out = append(out, key)
 	}
 	return out
 }
@@ -124,15 +124,15 @@ func TestDeriveAPIKey_HappyPath(t *testing.T) {
 
 	address, sigHex := signedEIP712(t)
 	repo := newFakeRepo()
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 
-	r := l1Request(t, address, sigHex, "1700000000", "0")
-	w := httptest.NewRecorder()
+	request := l1Request(t, address, sigHex, "1700000000", "0")
+	recorder := httptest.NewRecorder()
 
-	h.deriveAPIKey(w, r)
+	handler.deriveAPIKey(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 
 	var resp struct {
@@ -140,14 +140,14 @@ func TestDeriveAPIKey_HappyPath(t *testing.T) {
 		Secret     string `json:"secret"`
 		Passphrase string `json:"passphrase"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+	if err := json.NewDecoder(recorder.Body).Decode(&resp); err != nil {
 		t.Fatalf("decoding response: %v", err)
 	}
 	if resp.APIKey == "" || resp.Secret == "" || resp.Passphrase == "" {
 		t.Errorf("response fields empty: %+v", resp)
 	}
-	if strings.Contains(w.Body.String(), "expires_at") || strings.Contains(w.Body.String(), "expiresAt") {
-		t.Errorf("response must not include expires_at field, got: %s", w.Body.String())
+	if strings.Contains(recorder.Body.String(), "expires_at") || strings.Contains(recorder.Body.String(), "expiresAt") {
+		t.Errorf("response must not include expires_at field, got: %s", recorder.Body.String())
 	}
 	if len(repo.apiKeys) != 1 {
 		t.Errorf("repo apiKeys count = %d, want 1", len(repo.apiKeys))
@@ -166,26 +166,26 @@ func TestDeriveAPIKey_SDKShapedRequest(t *testing.T) {
 
 	address, sigHex := signedEIP712(t)
 	repo := newFakeRepo()
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 
 	mux := http.NewServeMux()
-	h.RegisterRoutes(mux, nil)
+	handler.RegisterRoutes(mux, nil)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/derive-api-key", nil)
-	r.Header.Set("POLY_ADDRESS", address)
-	r.Header.Set("POLY_SIGNATURE", sigHex)
-	r.Header.Set("POLY_TIMESTAMP", "1700000000")
-	r.Header.Set("POLY_NONCE", "0")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/auth/derive-api-key", nil)
+	request.Header.Set("POLY_ADDRESS", address)
+	request.Header.Set("POLY_SIGNATURE", sigHex)
+	request.Header.Set("POLY_TIMESTAMP", "1700000000")
+	request.Header.Set("POLY_NONCE", "0")
+	recorder := httptest.NewRecorder()
 
-	mux.ServeHTTP(w, r)
+	mux.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 
 	var raw map[string]interface{}
-	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+	if err := json.Unmarshal(recorder.Body.Bytes(), &raw); err != nil {
 		t.Fatalf("decoding response: %v", err)
 	}
 	for _, field := range []string{"apiKey", "secret", "passphrase"} {
@@ -205,18 +205,18 @@ func TestDeriveAPIKey_DefaultNonce(t *testing.T) {
 
 	address, sigHex := signedEIP712(t)
 	repo := newFakeRepo()
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/derive-api-key", nil)
-	r.Header.Set(HeaderAddress, address)
-	r.Header.Set(HeaderSignature, sigHex)
-	r.Header.Set(HeaderTimestamp, "1700000000")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/auth/derive-api-key", nil)
+	request.Header.Set(HeaderAddress, address)
+	request.Header.Set(HeaderSignature, sigHex)
+	request.Header.Set(HeaderTimestamp, "1700000000")
+	recorder := httptest.NewRecorder()
 
-	h.deriveAPIKey(w, r)
+	handler.deriveAPIKey(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 }
 
@@ -224,15 +224,15 @@ func TestDeriveAPIKey_MissingHeaders(t *testing.T) {
 	t.Parallel()
 
 	repo := newFakeRepo()
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/derive-api-key", nil)
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/auth/derive-api-key", nil)
+	recorder := httptest.NewRecorder()
 
-	h.deriveAPIKey(w, r)
+	handler.deriveAPIKey(recorder, request)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
 }
 
@@ -240,18 +240,18 @@ func TestDeriveAPIKey_InvalidSignature(t *testing.T) {
 	t.Parallel()
 
 	repo := newFakeRepo()
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 
 	addr := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	badSig := "0x" + hex.EncodeToString(make([]byte, 65))
 
-	r := l1Request(t, addr, badSig, "1700000000", "0")
-	w := httptest.NewRecorder()
+	request := l1Request(t, addr, badSig, "1700000000", "0")
+	recorder := httptest.NewRecorder()
 
-	h.deriveAPIKey(w, r)
+	handler.deriveAPIKey(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -260,28 +260,28 @@ func TestDeriveAPIKey_Idempotent(t *testing.T) {
 
 	address, sigHex := signedEIP712(t)
 	repo := newFakeRepo()
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 
 	call := func() (apiKey, secret, passphrase string) {
-		rq := l1Request(t, address, sigHex, "1700000000", "0")
-		rw := httptest.NewRecorder()
-		h.deriveAPIKey(rw, rq)
-		if rw.Code != http.StatusOK {
-			t.Fatalf("status = %d, want %d, body: %s", rw.Code, http.StatusOK, rw.Body.String())
+		request := l1Request(t, address, sigHex, "1700000000", "0")
+		recorder := httptest.NewRecorder()
+		handler.deriveAPIKey(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 		}
 		var resp struct {
 			APIKey     string `json:"apiKey"`
 			Secret     string `json:"secret"`
 			Passphrase string `json:"passphrase"`
 		}
-		json.NewDecoder(rw.Body).Decode(&resp)
+		json.NewDecoder(recorder.Body).Decode(&resp)
 		return resp.APIKey, resp.Secret, resp.Passphrase
 	}
 
-	k1, s1, p1 := call()
-	k2, s2, p2 := call()
-	if k1 != k2 || s1 != s2 || p1 != p2 {
-		t.Errorf("derive is not idempotent: (%q,%q,%q) vs (%q,%q,%q)", k1, s1, p1, k2, s2, p2)
+	key1, secret1, pass1 := call()
+	key2, secret2, pass2 := call()
+	if key1 != key2 || secret1 != secret2 || pass1 != pass2 {
+		t.Errorf("derive is not idempotent: (%q,%q,%q) vs (%q,%q,%q)", key1, secret1, pass1, key2, secret2, pass2)
 	}
 }
 
@@ -313,21 +313,21 @@ func seedAPIKey(t *testing.T, repo *fakeRepo, address string) (rawKey, secretB64
 	return rawKey, secretB64, passphrase
 }
 
-// signL2Request sets L2 HMAC headers on r with a signature over its
+// signL2Request sets L2 HMAC headers on request with a signature over its
 // method+path+body. Mirrors clob-client v5.8.2 signing rules.
-func signL2Request(t *testing.T, r *http.Request, apiKey, secretB64, passphrase, body string) {
+func signL2Request(t *testing.T, request *http.Request, apiKey, secretB64, passphrase, body string) {
 	t.Helper()
 	ts := strconv.FormatInt(time.Now().Unix(), 10)
-	msg := BuildHMACMessage(ts, r.Method, r.URL.Path, body)
+	msg := BuildHMACMessage(ts, request.Method, request.URL.Path, body)
 	secretBytes, _ := base64.URLEncoding.DecodeString(secretB64)
 	mac := hmac.New(sha256.New, secretBytes)
 	mac.Write([]byte(msg))
 	sig := base64.URLEncoding.EncodeToString(mac.Sum(nil))
 
-	r.Header.Set(HeaderAPIKey, apiKey)
-	r.Header.Set(HeaderTimestamp, ts)
-	r.Header.Set(HeaderSignature, sig)
-	r.Header.Set(HeaderPassphrase, passphrase)
+	request.Header.Set(HeaderAPIKey, apiKey)
+	request.Header.Set(HeaderTimestamp, ts)
+	request.Header.Set(HeaderSignature, sig)
+	request.Header.Set(HeaderPassphrase, passphrase)
 }
 
 func TestRevokeAPIKey_Success(t *testing.T) {
@@ -346,19 +346,19 @@ func TestRevokeAPIKey_Success(t *testing.T) {
 
 	callerKey, callerSecret, callerPass := seedAPIKey(t, repo, addr)
 
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 	mux := http.NewServeMux()
-	h.RegisterRoutes(mux, nil)
+	handler.RegisterRoutes(mux, nil)
 
 	body := `{"api_key":"` + rawKeyToRevoke + `"}`
-	r := httptest.NewRequest(http.MethodDelete, "/auth/api-key", strings.NewReader(body))
-	signL2Request(t, r, callerKey, callerSecret, callerPass, body)
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodDelete, "/auth/api-key", strings.NewReader(body))
+	signL2Request(t, request, callerKey, callerSecret, callerPass, body)
+	recorder := httptest.NewRecorder()
 
-	mux.ServeHTTP(w, r)
+	mux.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("status = %d, want %d, body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d, body: %s", recorder.Code, http.StatusNoContent, recorder.Body.String())
 	}
 	if !repo.apiKeys[keyHash].Revoked {
 		t.Error("expected api key to be marked revoked")
@@ -372,19 +372,19 @@ func TestRevokeAPIKey_NotFound(t *testing.T) {
 	repo := newFakeRepo()
 	callerKey, callerSecret, callerPass := seedAPIKey(t, repo, addr)
 
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 	mux := http.NewServeMux()
-	h.RegisterRoutes(mux, nil)
+	handler.RegisterRoutes(mux, nil)
 
 	body := `{"api_key":"does-not-exist"}`
-	r := httptest.NewRequest(http.MethodDelete, "/auth/api-key", strings.NewReader(body))
-	signL2Request(t, r, callerKey, callerSecret, callerPass, body)
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodDelete, "/auth/api-key", strings.NewReader(body))
+	signL2Request(t, request, callerKey, callerSecret, callerPass, body)
+	recorder := httptest.NewRecorder()
 
-	mux.ServeHTTP(w, r)
+	mux.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusNotFound {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusNotFound)
 	}
 }
 
@@ -395,18 +395,18 @@ func TestRevokeAPIKey_MissingField(t *testing.T) {
 	repo := newFakeRepo()
 	callerKey, callerSecret, callerPass := seedAPIKey(t, repo, addr)
 
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 	mux := http.NewServeMux()
-	h.RegisterRoutes(mux, nil)
+	handler.RegisterRoutes(mux, nil)
 
-	r := httptest.NewRequest(http.MethodDelete, "/auth/api-key", strings.NewReader("{}"))
-	signL2Request(t, r, callerKey, callerSecret, callerPass, "{}")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodDelete, "/auth/api-key", strings.NewReader("{}"))
+	signL2Request(t, request, callerKey, callerSecret, callerPass, "{}")
+	recorder := httptest.NewRecorder()
 
-	mux.ServeHTTP(w, r)
+	mux.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
 }
 
@@ -414,18 +414,18 @@ func TestRevokeAPIKey_RejectsJWT(t *testing.T) {
 	t.Parallel()
 
 	repo := newFakeRepo()
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 	mux := http.NewServeMux()
-	h.RegisterRoutes(mux, nil)
+	handler.RegisterRoutes(mux, nil)
 
-	r := httptest.NewRequest(http.MethodDelete, "/auth/api-key", strings.NewReader(`{"api_key":"x"}`))
-	r.Header.Set("Authorization", "Bearer some.jwt.token")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodDelete, "/auth/api-key", strings.NewReader(`{"api_key":"x"}`))
+	request.Header.Set("Authorization", "Bearer some.jwt.token")
+	recorder := httptest.NewRecorder()
 
-	mux.ServeHTTP(w, r)
+	mux.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d; CLOB routes must not accept JWT", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d; CLOB routes must not accept JWT", recorder.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -447,21 +447,21 @@ func TestListAPIKeys_WithKeys(t *testing.T) {
 	}
 	callerKey, callerSecret, callerPass := seedAPIKey(t, repo, addr)
 
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 	mux := http.NewServeMux()
-	h.RegisterRoutes(mux, nil)
+	handler.RegisterRoutes(mux, nil)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/api-keys", nil)
-	signL2Request(t, r, callerKey, callerSecret, callerPass, "")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/auth/api-keys", nil)
+	signL2Request(t, request, callerKey, callerSecret, callerPass, "")
+	recorder := httptest.NewRecorder()
 
-	mux.ServeHTTP(w, r)
+	mux.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 	var items []apiKeyListItem
-	if err := json.NewDecoder(w.Body).Decode(&items); err != nil {
+	if err := json.NewDecoder(recorder.Body).Decode(&items); err != nil {
 		t.Fatalf("decoding response: %v", err)
 	}
 	if len(items) != 3 {
@@ -482,20 +482,20 @@ func TestListAPIKeys_SecretsStripped(t *testing.T) {
 	}
 	callerKey, callerSecret, callerPass := seedAPIKey(t, repo, addr)
 
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 	mux := http.NewServeMux()
-	h.RegisterRoutes(mux, nil)
+	handler.RegisterRoutes(mux, nil)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/api-keys", nil)
-	signL2Request(t, r, callerKey, callerSecret, callerPass, "")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/auth/api-keys", nil)
+	signL2Request(t, request, callerKey, callerSecret, callerPass, "")
+	recorder := httptest.NewRecorder()
 
-	mux.ServeHTTP(w, r)
+	mux.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
 	}
-	if strings.Contains(w.Body.String(), "super-secret-ciphertext") {
+	if strings.Contains(recorder.Body.String(), "super-secret-ciphertext") {
 		t.Error("response must not include HMACSecretEncrypted")
 	}
 }
@@ -504,17 +504,17 @@ func TestListAPIKeys_RejectsJWT(t *testing.T) {
 	t.Parallel()
 
 	repo := newFakeRepo()
-	h := testHandler(t, repo)
+	handler := testHandler(t, repo)
 	mux := http.NewServeMux()
-	h.RegisterRoutes(mux, nil)
+	handler.RegisterRoutes(mux, nil)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/api-keys", nil)
-	r.Header.Set("Authorization", "Bearer some.jwt.token")
-	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/auth/api-keys", nil)
+	request.Header.Set("Authorization", "Bearer some.jwt.token")
+	recorder := httptest.NewRecorder()
 
-	mux.ServeHTTP(w, r)
+	mux.ServeHTTP(recorder, request)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d; CLOB routes must not accept JWT", w.Code, http.StatusUnauthorized)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d; CLOB routes must not accept JWT", recorder.Code, http.StatusUnauthorized)
 	}
 }

--- a/internal/trading/auth/middleware.go
+++ b/internal/trading/auth/middleware.go
@@ -49,8 +49,8 @@ type middlewareOptions struct {
 // signature mismatch, secret decrypt/decode failures. Does NOT fire on shape
 // errors (missing POLY_API_KEY, missing signature headers, invalid-timestamp
 // parse, body read error) — those are probes, not brute-force attempts.
-func WithAuthFailureHook(fn func(*http.Request)) MiddlewareOption {
-	return func(o *middlewareOptions) { o.onAuthFailure = fn }
+func WithAuthFailureHook(hook func(*http.Request)) MiddlewareOption {
+	return func(opts *middlewareOptions) { opts.onAuthFailure = hook }
 }
 
 // AuthenticateAPIKey returns HTTP middleware that validates an L2 HMAC-signed
@@ -63,9 +63,9 @@ func WithAuthFailureHook(fn func(*http.Request)) MiddlewareOption {
 // token on a CLOB-protected route is rejected with 401 — enforcement of the
 // architectural rule that CLOB endpoints speak HMAC exclusively.
 func AuthenticateAPIKey(reader APIKeyReader, encryptionKey []byte, logger *zap.Logger, opts ...MiddlewareOption) func(http.Handler) http.Handler {
-	o := &middlewareOptions{}
-	for _, fn := range opts {
-		fn(o)
+	options := &middlewareOptions{}
+	for _, option := range opts {
+		option(options)
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -74,7 +74,7 @@ func AuthenticateAPIKey(reader APIKeyReader, encryptionKey []byte, logger *zap.L
 				httputil.ErrorResponse(w, http.StatusUnauthorized, "missing POLY_API_KEY header (this endpoint requires L2 HMAC auth)")
 				return
 			}
-			address, ok := authenticateAPIKey(w, r, apiKey, reader, encryptionKey, logger, o.onAuthFailure)
+			address, ok := authenticateAPIKey(w, r, apiKey, reader, encryptionKey, logger, options.onAuthFailure)
 			if !ok {
 				return
 			}

--- a/internal/trading/auth/pg_repository.go
+++ b/internal/trading/auth/pg_repository.go
@@ -27,11 +27,11 @@ func NewPGRepository(pool *pgxpool.Pool) *PGRepository {
 // updates expires_at, hmac_secret_encrypted, and passphrase_hash —
 // enabling idempotent re-derivation when the client presents the same
 // EIP-712 signature inputs.
-func (r *PGRepository) UpsertAPIKey(ctx context.Context, key *APIKey) error {
+func (repo *PGRepository) UpsertAPIKey(ctx context.Context, key *APIKey) error {
 	if err := ValidateAPIKey(key); err != nil {
 		return fmt.Errorf("upserting api key: %w", err)
 	}
-	_, err := r.pool.Exec(ctx,
+	_, err := repo.pool.Exec(ctx,
 		`INSERT INTO api_keys (key_hash, user_address, hmac_secret_encrypted, passphrase_hash, label, expires_at)
 		 VALUES ($1, $2, $3, $4, $5, $6)
 		 ON CONFLICT (key_hash)
@@ -48,8 +48,8 @@ func (r *PGRepository) UpsertAPIKey(ctx context.Context, key *APIKey) error {
 // GetAPIKeyByHash retrieves a single non-revoked, non-expired API key by its
 // hash. Implements APIKeyReader so the HMAC middleware (same package) can use
 // this repository directly for L2 verification.
-func (r *PGRepository) GetAPIKeyByHash(ctx context.Context, keyHash string) (*APIKey, error) {
-	rows, err := r.pool.Query(ctx,
+func (repo *PGRepository) GetAPIKeyByHash(ctx context.Context, keyHash string) (*APIKey, error) {
+	rows, err := repo.pool.Query(ctx,
 		`SELECT * FROM api_keys
 		 WHERE key_hash = $1 AND revoked = false AND expires_at > now()`,
 		keyHash,
@@ -69,8 +69,8 @@ func (r *PGRepository) GetAPIKeyByHash(ctx context.Context, keyHash string) (*AP
 
 // GetAPIKeysByUser returns all non-revoked, non-expired API keys for a user,
 // ordered by created_at descending (newest first).
-func (r *PGRepository) GetAPIKeysByUser(ctx context.Context, userAddress string) ([]*APIKey, error) {
-	rows, err := r.pool.Query(ctx,
+func (repo *PGRepository) GetAPIKeysByUser(ctx context.Context, userAddress string) ([]*APIKey, error) {
+	rows, err := repo.pool.Query(ctx,
 		`SELECT * FROM api_keys
 		 WHERE user_address = $1 AND revoked = false AND expires_at > now()
 		 ORDER BY created_at DESC`,
@@ -89,8 +89,8 @@ func (r *PGRepository) GetAPIKeysByUser(ctx context.Context, userAddress string)
 // RevokeAPIKey marks an API key as revoked by its key_hash, scoped by user.
 // Returns data.ErrNotFound if the key does not exist or does not belong to
 // the given user.
-func (r *PGRepository) RevokeAPIKey(ctx context.Context, keyHash string, userAddress string) error {
-	tag, err := r.pool.Exec(ctx,
+func (repo *PGRepository) RevokeAPIKey(ctx context.Context, keyHash string, userAddress string) error {
+	tag, err := repo.pool.Exec(ctx,
 		`UPDATE api_keys SET revoked = true
 		 WHERE key_hash = $1 AND user_address = $2 AND revoked = false`,
 		keyHash, userAddress,

--- a/internal/trading/domain.go
+++ b/internal/trading/domain.go
@@ -26,8 +26,8 @@ const (
 	SideSell Side = 1
 )
 
-func (s Side) String() string {
-	switch s {
+func (side Side) String() string {
+	switch side {
 	case SideBuy:
 		return "BUY"
 	case SideSell:
@@ -38,8 +38,8 @@ func (s Side) String() string {
 }
 
 // IsValid returns true if the side is BUY or SELL.
-func (s Side) IsValid() bool {
-	return s == SideBuy || s == SideSell
+func (side Side) IsValid() bool {
+	return side == SideBuy || side == SideSell
 }
 
 // OrderStatus represents the lifecycle state of an order.
@@ -52,8 +52,8 @@ const (
 	OrderStatusCancelled       OrderStatus = 3
 )
 
-func (s OrderStatus) String() string {
-	switch s {
+func (status OrderStatus) String() string {
+	switch status {
 	case OrderStatusOpen:
 		return "OPEN"
 	case OrderStatusFilled:
@@ -68,8 +68,8 @@ func (s OrderStatus) String() string {
 }
 
 // IsValid returns true if the status is a known value.
-func (s OrderStatus) IsValid() bool {
-	return s >= OrderStatusOpen && s <= OrderStatusCancelled
+func (status OrderStatus) IsValid() bool {
+	return status >= OrderStatusOpen && status <= OrderStatusCancelled
 }
 
 // OrderType represents the execution strategy of an order.
@@ -80,8 +80,8 @@ const (
 	OrderTypeFOK OrderType = 1 // Fill-Or-Kill: must fill entirely on arrival or be rejected.
 )
 
-func (t OrderType) String() string {
-	switch t {
+func (orderType OrderType) String() string {
+	switch orderType {
 	case OrderTypeGTC:
 		return "GTC"
 	case OrderTypeFOK:
@@ -92,8 +92,8 @@ func (t OrderType) String() string {
 }
 
 // IsValid returns true if the order type is GTC or FOK.
-func (t OrderType) IsValid() bool {
-	return t == OrderTypeGTC || t == OrderTypeFOK
+func (orderType OrderType) IsValid() bool {
+	return orderType == OrderTypeGTC || orderType == OrderTypeFOK
 }
 
 // Order represents a signed order submitted to the CLOB.
@@ -123,12 +123,12 @@ type Order struct {
 // OrderPrice computes the price in integer cents from maker/taker amounts.
 // Price = MakerAmount / (MakerAmount + TakerAmount) * 100.
 // Returns 0 if total is zero (invalid order).
-func OrderPrice(o *Order) int64 {
-	total := o.MakerAmount + o.TakerAmount
+func OrderPrice(order *Order) int64 {
+	total := order.MakerAmount + order.TakerAmount
 	if total == 0 {
 		return 0
 	}
-	return (o.MakerAmount * 100) / total
+	return (order.MakerAmount * 100) / total
 }
 
 // Trade represents a matched trade between two orders.
@@ -159,8 +159,8 @@ type Balance struct {
 }
 
 // Total returns the sum of available and reserved funds.
-func (b Balance) Total() int64 {
-	return b.Available + b.Reserved
+func (balance Balance) Total() int64 {
+	return balance.Available + balance.Reserved
 }
 
 // TokenPair represents the YES and NO token IDs for a single market.

--- a/internal/trading/domain_test.go
+++ b/internal/trading/domain_test.go
@@ -160,8 +160,8 @@ func TestBalance_Total(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			b := Balance{Available: tt.available, Reserved: tt.reserved}
-			if got := b.Total(); got != tt.want {
+			balance := Balance{Available: tt.available, Reserved: tt.reserved}
+			if got := balance.Total(); got != tt.want {
 				t.Errorf("Balance{Available: %d, Reserved: %d}.Total() = %d, want %d",
 					tt.available, tt.reserved, got, tt.want)
 			}
@@ -189,8 +189,8 @@ func TestOrderPrice(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			o := &Order{MakerAmount: tt.makerAmount, TakerAmount: tt.takerAmount}
-			if got := OrderPrice(o); got != tt.want {
+			order := &Order{MakerAmount: tt.makerAmount, TakerAmount: tt.takerAmount}
+			if got := OrderPrice(order); got != tt.want {
 				t.Errorf("OrderPrice(maker=%d, taker=%d) = %d, want %d",
 					tt.makerAmount, tt.takerAmount, got, tt.want)
 			}

--- a/internal/trading/pg_repository.go
+++ b/internal/trading/pg_repository.go
@@ -23,8 +23,8 @@ func NewPGRepository(pool *pgxpool.Pool) *PGRepository {
 
 // SaveOrder persists a new order. Returns ErrDuplicateOrder if the signature
 // hash already exists.
-func (r *PGRepository) SaveOrder(ctx context.Context, order *Order) error {
-	tx, err := r.pool.Begin(ctx)
+func (repo *PGRepository) SaveOrder(ctx context.Context, order *Order) error {
+	tx, err := repo.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("saving order: beginning transaction: %w", err)
 	}
@@ -65,8 +65,8 @@ func (r *PGRepository) SaveOrder(ctx context.Context, order *Order) error {
 }
 
 // GetOrder retrieves an order by ID. Returns ErrNotFound if not found.
-func (r *PGRepository) GetOrder(ctx context.Context, id string) (*Order, error) {
-	rows, err := r.pool.Query(ctx, `SELECT * FROM orders WHERE id = $1`, id)
+func (repo *PGRepository) GetOrder(ctx context.Context, id string) (*Order, error) {
+	rows, err := repo.pool.Query(ctx, `SELECT * FROM orders WHERE id = $1`, id)
 	if err != nil {
 		return nil, fmt.Errorf("getting order %s: %w", id, err)
 	}
@@ -81,17 +81,17 @@ func (r *PGRepository) GetOrder(ctx context.Context, id string) (*Order, error) 
 }
 
 // ListOrdersByUser returns orders for a user, optionally filtered by statuses.
-func (r *PGRepository) ListOrdersByUser(ctx context.Context, userAddress string, statuses []OrderStatus) ([]*Order, error) {
+func (repo *PGRepository) ListOrdersByUser(ctx context.Context, userAddress string, statuses []OrderStatus) ([]*Order, error) {
 	var rows pgx.Rows
 	var err error
 
 	if len(statuses) == 0 {
-		rows, err = r.pool.Query(ctx,
+		rows, err = repo.pool.Query(ctx,
 			`SELECT * FROM orders WHERE maker = $1 ORDER BY created_at DESC`,
 			userAddress,
 		)
 	} else {
-		rows, err = r.pool.Query(ctx,
+		rows, err = repo.pool.Query(ctx,
 			`SELECT * FROM orders WHERE maker = $1 AND status = ANY($2) ORDER BY created_at DESC`,
 			userAddress, statusSlice(statuses),
 		)
@@ -107,17 +107,17 @@ func (r *PGRepository) ListOrdersByUser(ctx context.Context, userAddress string,
 }
 
 // ListOrdersByMarket returns orders for a market, optionally filtered by statuses.
-func (r *PGRepository) ListOrdersByMarket(ctx context.Context, marketID string, statuses []OrderStatus) ([]*Order, error) {
+func (repo *PGRepository) ListOrdersByMarket(ctx context.Context, marketID string, statuses []OrderStatus) ([]*Order, error) {
 	var rows pgx.Rows
 	var err error
 
 	if len(statuses) == 0 {
-		rows, err = r.pool.Query(ctx,
+		rows, err = repo.pool.Query(ctx,
 			`SELECT * FROM orders WHERE market_id = $1 ORDER BY created_at DESC`,
 			marketID,
 		)
 	} else {
-		rows, err = r.pool.Query(ctx,
+		rows, err = repo.pool.Query(ctx,
 			`SELECT * FROM orders WHERE market_id = $1 AND status = ANY($2) ORDER BY created_at DESC`,
 			marketID, statusSlice(statuses),
 		)
@@ -134,8 +134,8 @@ func (r *PGRepository) ListOrdersByMarket(ctx context.Context, marketID string, 
 
 // UpdateOrderStatus changes the status of an order. Returns ErrNotFound if the
 // order does not exist.
-func (r *PGRepository) UpdateOrderStatus(ctx context.Context, id string, status OrderStatus) error {
-	tag, err := r.pool.Exec(ctx,
+func (repo *PGRepository) UpdateOrderStatus(ctx context.Context, id string, status OrderStatus) error {
+	tag, err := repo.pool.Exec(ctx,
 		`UPDATE orders SET status = $1, updated_at = now() WHERE id = $2`,
 		status, id,
 	)
@@ -150,8 +150,8 @@ func (r *PGRepository) UpdateOrderStatus(ctx context.Context, id string, status 
 
 // SaveTrade persists a new trade. Returns ErrDuplicateTrade if the match ID
 // already exists.
-func (r *PGRepository) SaveTrade(ctx context.Context, trade *Trade) error {
-	tx, err := r.pool.Begin(ctx)
+func (repo *PGRepository) SaveTrade(ctx context.Context, trade *Trade) error {
+	tx, err := repo.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("saving trade: beginning transaction: %w", err)
 	}
@@ -190,24 +190,24 @@ func (r *PGRepository) SaveTrade(ctx context.Context, trade *Trade) error {
 
 // GetBalance retrieves the balance for a user. Returns a zero-value Balance
 // if the user has no row.
-func (r *PGRepository) GetBalance(ctx context.Context, userAddress string) (*Balance, error) {
-	b := &Balance{UserAddress: userAddress}
-	err := r.pool.QueryRow(ctx,
+func (repo *PGRepository) GetBalance(ctx context.Context, userAddress string) (*Balance, error) {
+	balance := &Balance{UserAddress: userAddress}
+	err := repo.pool.QueryRow(ctx,
 		`SELECT available, reserved, updated_at
 		FROM balances WHERE user_address = $1`, userAddress,
-	).Scan(&b.Available, &b.Reserved, &b.UpdatedAt)
+	).Scan(&balance.Available, &balance.Reserved, &balance.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return &Balance{UserAddress: userAddress}, nil
 		}
 		return nil, fmt.Errorf("getting balance for %s: %w", userAddress, err)
 	}
-	return b, nil
+	return balance, nil
 }
 
 // ReserveBalance atomically moves funds from available to reserved.
-func (r *PGRepository) ReserveBalance(ctx context.Context, userAddress string, amount int64) error {
-	tx, err := r.pool.Begin(ctx)
+func (repo *PGRepository) ReserveBalance(ctx context.Context, userAddress string, amount int64) error {
+	tx, err := repo.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("reserving balance: beginning transaction: %w", err)
 	}
@@ -246,8 +246,8 @@ func (r *PGRepository) ReserveBalance(ctx context.Context, userAddress string, a
 }
 
 // ReleaseBalance atomically moves funds from reserved back to available.
-func (r *PGRepository) ReleaseBalance(ctx context.Context, userAddress string, amount int64) error {
-	tx, err := r.pool.Begin(ctx)
+func (repo *PGRepository) ReleaseBalance(ctx context.Context, userAddress string, amount int64) error {
+	tx, err := repo.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("releasing balance: beginning transaction: %w", err)
 	}
@@ -272,8 +272,8 @@ func (r *PGRepository) ReleaseBalance(ctx context.Context, userAddress string, a
 }
 
 // DeductReserved atomically removes funds from reserved after a trade fills.
-func (r *PGRepository) DeductReserved(ctx context.Context, userAddress string, amount int64) error {
-	tx, err := r.pool.Begin(ctx)
+func (repo *PGRepository) DeductReserved(ctx context.Context, userAddress string, amount int64) error {
+	tx, err := repo.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("deducting reserved: beginning transaction: %w", err)
 	}
@@ -299,8 +299,8 @@ func (r *PGRepository) DeductReserved(ctx context.Context, userAddress string, a
 
 // CreditAvailable adds funds to a user's available balance.
 // Creates the balance row if it does not exist (UPSERT).
-func (r *PGRepository) CreditAvailable(ctx context.Context, userAddress string, amount int64) error {
-	_, err := r.pool.Exec(ctx,
+func (repo *PGRepository) CreditAvailable(ctx context.Context, userAddress string, amount int64) error {
+	_, err := repo.pool.Exec(ctx,
 		`INSERT INTO balances (user_address, available, reserved, updated_at)
 		 VALUES ($1, $2, 0, now())
 		 ON CONFLICT (user_address)
@@ -316,8 +316,8 @@ func (r *PGRepository) CreditAvailable(ctx context.Context, userAddress string, 
 // statusSlice converts OrderStatus values to int16 for pgx ANY() binding.
 func statusSlice(statuses []OrderStatus) []int16 {
 	out := make([]int16, len(statuses))
-	for i, s := range statuses {
-		out[i] = int16(s)
+	for idx, status := range statuses {
+		out[idx] = int16(status)
 	}
 	return out
 }

--- a/internal/trading/pg_repository_test.go
+++ b/internal/trading/pg_repository_test.go
@@ -125,21 +125,21 @@ func TestPGRepository_ListOrdersByUser_StatusFilter(t *testing.T) {
 	repo := NewPGRepository(pool)
 	ctx := context.Background()
 
-	for i, status := range []OrderStatus{OrderStatusOpen, OrderStatusFilled, OrderStatusOpen} {
-		o := &Order{
+	for idx, status := range []OrderStatus{OrderStatusOpen, OrderStatusFilled, OrderStatusOpen} {
+		order := &Order{
 			Maker:         "0xfilteruser",
 			TokenID:       "token-1",
 			MakerAmount:   40,
 			TakerAmount:   60,
-			Salt:          fmt.Sprintf("salt-filter-%d", i),
-			Signature:     fmt.Sprintf("sig-filter-%d", i),
+			Salt:          fmt.Sprintf("salt-filter-%d", idx),
+			Signature:     fmt.Sprintf("sig-filter-%d", idx),
 			Status:        status,
 			OrderType:     OrderTypeGTC,
 			MarketID:      "a0000000-0000-0000-0000-000000000001",
-			SignatureHash: fmt.Sprintf("hash-filter-%d", i),
+			SignatureHash: fmt.Sprintf("hash-filter-%d", idx),
 		}
-		if err := repo.SaveOrder(ctx, o); err != nil {
-			t.Fatalf("SaveOrder %d: %v", i, err)
+		if err := repo.SaveOrder(ctx, order); err != nil {
+			t.Fatalf("SaveOrder %d: %v", idx, err)
 		}
 	}
 
@@ -169,21 +169,21 @@ func TestPGRepository_ListOrdersByMarket(t *testing.T) {
 	marketA := "a0000000-0000-0000-0000-000000000001"
 	marketB := "b0000000-0000-0000-0000-000000000002"
 
-	for i, mkt := range []string{marketA, marketA, marketB} {
-		o := &Order{
+	for idx, market := range []string{marketA, marketA, marketB} {
+		order := &Order{
 			Maker:         "0xmaker",
 			TokenID:       "token-1",
 			MakerAmount:   50,
 			TakerAmount:   50,
-			Salt:          fmt.Sprintf("salt-mkt-%d", i),
-			Signature:     fmt.Sprintf("sig-mkt-%d", i),
+			Salt:          fmt.Sprintf("salt-mkt-%d", idx),
+			Signature:     fmt.Sprintf("sig-mkt-%d", idx),
 			Status:        OrderStatusOpen,
 			OrderType:     OrderTypeGTC,
-			MarketID:      mkt,
-			SignatureHash: fmt.Sprintf("hash-mkt-%d", i),
+			MarketID:      market,
+			SignatureHash: fmt.Sprintf("hash-mkt-%d", idx),
 		}
-		if err := repo.SaveOrder(ctx, o); err != nil {
-			t.Fatalf("SaveOrder %d: %v", i, err)
+		if err := repo.SaveOrder(ctx, order); err != nil {
+			t.Fatalf("SaveOrder %d: %v", idx, err)
 		}
 	}
 
@@ -202,7 +202,7 @@ func TestPGRepository_UpdateOrderStatus(t *testing.T) {
 	repo := NewPGRepository(pool)
 	ctx := context.Background()
 
-	o := &Order{
+	order := &Order{
 		Maker:         "0xstatus",
 		TokenID:       "token-1",
 		MakerAmount:   40,
@@ -214,7 +214,7 @@ func TestPGRepository_UpdateOrderStatus(t *testing.T) {
 		MarketID:      "a0000000-0000-0000-0000-000000000001",
 		SignatureHash: "hash-status",
 	}
-	if err := repo.SaveOrder(ctx, o); err != nil {
+	if err := repo.SaveOrder(ctx, order); err != nil {
 		t.Fatalf("SaveOrder: %v", err)
 	}
 
@@ -251,21 +251,21 @@ func TestPGRepository_SaveTrade(t *testing.T) {
 
 	// Create two orders first (FK constraint).
 	marketID := "a0000000-0000-0000-0000-000000000001"
-	for i, sig := range []string{"sig-trade-maker", "sig-trade-taker"} {
-		o := &Order{
-			Maker:         fmt.Sprintf("0xtrader%d", i),
+	for idx, sig := range []string{"sig-trade-maker", "sig-trade-taker"} {
+		order := &Order{
+			Maker:         fmt.Sprintf("0xtrader%d", idx),
 			TokenID:       "token-1",
 			MakerAmount:   50,
 			TakerAmount:   50,
-			Salt:          fmt.Sprintf("salt-trade-%d", i),
+			Salt:          fmt.Sprintf("salt-trade-%d", idx),
 			Signature:     sig,
 			Status:        OrderStatusOpen,
 			OrderType:     OrderTypeGTC,
 			MarketID:      marketID,
-			SignatureHash: fmt.Sprintf("hash-trade-%d", i),
+			SignatureHash: fmt.Sprintf("hash-trade-%d", idx),
 		}
-		if err := repo.SaveOrder(ctx, o); err != nil {
-			t.Fatalf("SaveOrder %d: %v", i, err)
+		if err := repo.SaveOrder(ctx, order); err != nil {
+			t.Fatalf("SaveOrder %d: %v", idx, err)
 		}
 	}
 
@@ -306,12 +306,12 @@ func TestPGRepository_Balance_CreditAndReserve(t *testing.T) {
 	addr := "0xbalance1"
 
 	// GetBalance for non-existent user returns zero.
-	b, err := repo.GetBalance(ctx, addr)
+	balance, err := repo.GetBalance(ctx, addr)
 	if err != nil {
 		t.Fatalf("GetBalance: %v", err)
 	}
-	if b.Available != 0 || b.Reserved != 0 {
-		t.Errorf("expected zero balance, got available=%d reserved=%d", b.Available, b.Reserved)
+	if balance.Available != 0 || balance.Reserved != 0 {
+		t.Errorf("expected zero balance, got available=%d reserved=%d", balance.Available, balance.Reserved)
 	}
 
 	// Credit creates the row.
@@ -319,9 +319,9 @@ func TestPGRepository_Balance_CreditAndReserve(t *testing.T) {
 		t.Fatalf("CreditAvailable: %v", err)
 	}
 
-	b, _ = repo.GetBalance(ctx, addr)
-	if b.Available != 1000 {
-		t.Errorf("available = %d, want 1000", b.Available)
+	balance, _ = repo.GetBalance(ctx, addr)
+	if balance.Available != 1000 {
+		t.Errorf("available = %d, want 1000", balance.Available)
 	}
 
 	// Credit again adds to existing.
@@ -329,9 +329,9 @@ func TestPGRepository_Balance_CreditAndReserve(t *testing.T) {
 		t.Fatalf("CreditAvailable (2nd): %v", err)
 	}
 
-	b, _ = repo.GetBalance(ctx, addr)
-	if b.Available != 1500 {
-		t.Errorf("available = %d, want 1500", b.Available)
+	balance, _ = repo.GetBalance(ctx, addr)
+	if balance.Available != 1500 {
+		t.Errorf("available = %d, want 1500", balance.Available)
 	}
 
 	// Reserve moves from available to reserved.
@@ -339,9 +339,9 @@ func TestPGRepository_Balance_CreditAndReserve(t *testing.T) {
 		t.Fatalf("ReserveBalance: %v", err)
 	}
 
-	b, _ = repo.GetBalance(ctx, addr)
-	if b.Available != 1100 || b.Reserved != 400 {
-		t.Errorf("after reserve: available=%d reserved=%d, want 1100/400", b.Available, b.Reserved)
+	balance, _ = repo.GetBalance(ctx, addr)
+	if balance.Available != 1100 || balance.Reserved != 400 {
+		t.Errorf("after reserve: available=%d reserved=%d, want 1100/400", balance.Available, balance.Reserved)
 	}
 
 	// Release moves from reserved back to available.
@@ -349,9 +349,9 @@ func TestPGRepository_Balance_CreditAndReserve(t *testing.T) {
 		t.Fatalf("ReleaseBalance: %v", err)
 	}
 
-	b, _ = repo.GetBalance(ctx, addr)
-	if b.Available != 1200 || b.Reserved != 300 {
-		t.Errorf("after release: available=%d reserved=%d, want 1200/300", b.Available, b.Reserved)
+	balance, _ = repo.GetBalance(ctx, addr)
+	if balance.Available != 1200 || balance.Reserved != 300 {
+		t.Errorf("after release: available=%d reserved=%d, want 1200/300", balance.Available, balance.Reserved)
 	}
 
 	// DeductReserved removes from reserved (trade settled).
@@ -359,12 +359,12 @@ func TestPGRepository_Balance_CreditAndReserve(t *testing.T) {
 		t.Fatalf("DeductReserved: %v", err)
 	}
 
-	b, _ = repo.GetBalance(ctx, addr)
-	if b.Available != 1200 || b.Reserved != 100 {
-		t.Errorf("after deduct: available=%d reserved=%d, want 1200/100", b.Available, b.Reserved)
+	balance, _ = repo.GetBalance(ctx, addr)
+	if balance.Available != 1200 || balance.Reserved != 100 {
+		t.Errorf("after deduct: available=%d reserved=%d, want 1200/100", balance.Available, balance.Reserved)
 	}
-	if b.Total() != 1300 {
-		t.Errorf("total = %d, want 1300", b.Total())
+	if balance.Total() != 1300 {
+		t.Errorf("total = %d, want 1300", balance.Total())
 	}
 }
 

--- a/internal/trading/validate_test.go
+++ b/internal/trading/validate_test.go
@@ -42,122 +42,122 @@ func TestValidateOrder(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		modify  func(o *Order, c *MarketConfig)
+		modify  func(order *Order, config *MarketConfig)
 		wantErr bool
 	}{
 		{
 			name:    "valid order passes",
-			modify:  func(o *Order, c *MarketConfig) {},
+			modify:  func(order *Order, config *MarketConfig) {},
 			wantErr: false,
 		},
 		{
 			name:    "zero maker amount",
-			modify:  func(o *Order, c *MarketConfig) { o.MakerAmount = 0 },
+			modify:  func(order *Order, config *MarketConfig) { order.MakerAmount = 0 },
 			wantErr: true,
 		},
 		{
 			name:    "negative maker amount",
-			modify:  func(o *Order, c *MarketConfig) { o.MakerAmount = -1 },
+			modify:  func(order *Order, config *MarketConfig) { order.MakerAmount = -1 },
 			wantErr: true,
 		},
 		{
 			name:    "zero taker amount",
-			modify:  func(o *Order, c *MarketConfig) { o.TakerAmount = 0 },
+			modify:  func(order *Order, config *MarketConfig) { order.TakerAmount = 0 },
 			wantErr: true,
 		},
 		{
 			name:    "negative taker amount",
-			modify:  func(o *Order, c *MarketConfig) { o.TakerAmount = -5 },
+			modify:  func(order *Order, config *MarketConfig) { order.TakerAmount = -5 },
 			wantErr: true,
 		},
 		{
 			name: "price too low",
-			modify: func(o *Order, c *MarketConfig) {
+			modify: func(order *Order, config *MarketConfig) {
 				// Price = 0 cents: maker=0, taker=100 would fail on maker<=0 first,
 				// so use amounts that produce price=0 via integer division.
-				o.MakerAmount = 0
-				o.TakerAmount = 100
+				order.MakerAmount = 0
+				order.TakerAmount = 100
 			},
 			wantErr: true, // Fails on maker amount <= 0.
 		},
 		{
 			name: "price too high at 100",
-			modify: func(o *Order, c *MarketConfig) {
+			modify: func(order *Order, config *MarketConfig) {
 				// Price = 100: taker must be 0 but that fails taker<=0 check.
-				o.MakerAmount = 100
-				o.TakerAmount = 0
+				order.MakerAmount = 100
+				order.TakerAmount = 0
 			},
 			wantErr: true, // Fails on taker amount <= 0.
 		},
 		{
 			name: "price not on tick size 5",
-			modify: func(o *Order, c *MarketConfig) {
-				c.TickSize = 5
-				o.MakerAmount = 33 // Price = 33, not divisible by 5.
-				o.TakerAmount = 67
+			modify: func(order *Order, config *MarketConfig) {
+				config.TickSize = 5
+				order.MakerAmount = 33 // Price = 33, not divisible by 5.
+				order.TakerAmount = 67
 			},
 			wantErr: true,
 		},
 		{
 			name: "price on tick size 5",
-			modify: func(o *Order, c *MarketConfig) {
-				c.TickSize = 5
-				o.MakerAmount = 35 // Price = 35, divisible by 5.
-				o.TakerAmount = 65
+			modify: func(order *Order, config *MarketConfig) {
+				config.TickSize = 5
+				order.MakerAmount = 35 // Price = 35, divisible by 5.
+				order.TakerAmount = 65
 			},
 			wantErr: false,
 		},
 		{
 			name: "size below minimum",
-			modify: func(o *Order, c *MarketConfig) {
-				c.MinSize = 100
-				o.TakerAmount = 50
-				o.MakerAmount = 50 // Keep price valid.
+			modify: func(order *Order, config *MarketConfig) {
+				config.MinSize = 100
+				order.TakerAmount = 50
+				order.MakerAmount = 50 // Keep price valid.
 			},
 			wantErr: true,
 		},
 		{
 			name: "size above maximum",
-			modify: func(o *Order, c *MarketConfig) {
-				c.MaxSize = 10
-				o.TakerAmount = 50
-				o.MakerAmount = 50
+			modify: func(order *Order, config *MarketConfig) {
+				config.MaxSize = 10
+				order.TakerAmount = 50
+				order.MakerAmount = 50
 			},
 			wantErr: true,
 		},
 		{
 			name:    "invalid side",
-			modify:  func(o *Order, c *MarketConfig) { o.Side = Side(99) },
+			modify:  func(order *Order, config *MarketConfig) { order.Side = Side(99) },
 			wantErr: true,
 		},
 		{
 			name:    "invalid order type",
-			modify:  func(o *Order, c *MarketConfig) { o.OrderType = OrderType(99) },
+			modify:  func(order *Order, config *MarketConfig) { order.OrderType = OrderType(99) },
 			wantErr: true,
 		},
 		{
 			name:    "FOK order type is valid",
-			modify:  func(o *Order, c *MarketConfig) { o.OrderType = OrderTypeFOK },
+			modify:  func(order *Order, config *MarketConfig) { order.OrderType = OrderTypeFOK },
 			wantErr: false,
 		},
 		{
 			name:    "empty signature",
-			modify:  func(o *Order, c *MarketConfig) { o.Signature = "" },
+			modify:  func(order *Order, config *MarketConfig) { order.Signature = "" },
 			wantErr: true,
 		},
 		{
 			name:    "expired order",
-			modify:  func(o *Order, c *MarketConfig) { o.Expiration = now.Unix() - 1 },
+			modify:  func(order *Order, config *MarketConfig) { order.Expiration = now.Unix() - 1 },
 			wantErr: true,
 		},
 		{
 			name:    "no expiration (0) is valid",
-			modify:  func(o *Order, c *MarketConfig) { o.Expiration = 0 },
+			modify:  func(order *Order, config *MarketConfig) { order.Expiration = 0 },
 			wantErr: false,
 		},
 		{
 			name:    "expiration exactly at now is valid",
-			modify:  func(o *Order, c *MarketConfig) { o.Expiration = now.Unix() },
+			modify:  func(order *Order, config *MarketConfig) { order.Expiration = now.Unix() },
 			wantErr: false,
 		},
 	}
@@ -166,11 +166,11 @@ func TestValidateOrder(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			o := validOrder()
-			c := cfg // Copy so modifications don't leak between tests.
-			tt.modify(o, &c)
+			order := validOrder()
+			cfgCopy := cfg // Copy so modifications don't leak between tests.
+			tt.modify(order, &cfgCopy)
 
-			err := ValidateOrder(o, c, now)
+			err := ValidateOrder(order, cfgCopy, now)
 
 			if tt.wantErr && err == nil {
 				t.Error("expected error, got nil")


### PR DESCRIPTION
## Summary

- Apply the updated naming rule in `docs/conventions.md` across the entire Go codebase: method receivers, loop variables, short locals, and helper parameters now use full or partial words that convey meaning.
- 39 files changed across `internal/platform/`, `internal/trading/`, and `internal/shared/`. Mechanical rename only — no behavior changes.
- Exceptions preserved per the rule: `ctx`, `err`, `tx`, `ok`, `id`, `t *testing.T`, `b *testing.B`, and `w`/`r` inside actual HTTP handler signatures.

## Key renames

- Receivers — `(r *PGRepository)` → `(repo *PGRepository)`, `(h *Handler)` → `(handler *Handler)`, `(l *Limiter)` → `(limiter *Limiter)`, `(c *Client)` → `(client *Client)`, `(m *JWTManager)` → `(manager *JWTManager)`, `(s Side)` / `(s Status)` / `(t EventType)` etc. on enum types.
- Loop vars — `for i, s := range statuses` → `for idx, status := range statuses`; semantic names used when the element has meaning.
- Test locals — `h := testHandler(...)` → `handler`, `w := httptest.NewRecorder()` → `recorder`, `r := httptest.NewRequest(...)` → `request`.
- Helper params — `DecodeJSON` / `EncodeJSON` / `ErrorResponse` / `ClientIP` now use `request` / `writer` (only true handler signatures keep `w`/`r`).
- Closure option params — `fn` → `hook` / `option` for semantic clarity.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [ ] CI green on pushed branch