### PR TITLE
Add create-branch skill; wire begin-task to use it

### DIFF
--- a/.claude/skills/begin-task/SKILL.md
+++ b/.claude/skills/begin-task/SKILL.md
@@ -23,13 +23,14 @@ arguments:
    - If all blockers are closed, note this and proceed normally.
 3. Parse the issue title to derive a branch name: `{issue_number}-{short-kebab-description}`
 4. Ensure working tree is clean: `git status --porcelain`
-5. Create and checkout branch from main: `git checkout main && git pull && git checkout -b {branch_name}`
+5. Create the branch via the **`create-branch`** skill, which guarantees the branch is based on a freshly fetched `origin/main` rather than the current HEAD. Never run ad-hoc `git checkout -b` here.
 6. Move the issue to "In Progress" on the project board and assign it:
    - `gh issue edit {issue_number} --repo Shisa-Fosho/services --add-assignee @me`
    - Move to In Progress: `gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id {item_id} --field-id PVTSSF_lADOEC3v5M4BUX8izhBgiFs --single-select-option-id 47fc9ee4`
    - To get the item ID, run: `gh project item-list 2 --owner Shisa-Fosho --format json --limit 50 | node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8')); const i=d.items.find(x=>x.title.includes('{issue_title_fragment}')); if(i) console.log(i.id); else console.error('item not found');"`
 7. Enter plan mode to discuss approach before writing code
-8. **Size check (during planning):** After exploring the codebase and designing the implementation, estimate the total hand-written LOC (excluding generated code and tests). The target is **≤ 800 LOC of production code per PR**.
+8. Check if the issue has a parent and if so read the parent and any sibling issues so that you can gain full context around how the issue fits into the greater epic.
+9. **Size check (during planning):** After exploring the codebase and designing the implementation, estimate the total hand-written LOC (excluding generated code and tests). The target is **≤ 800 LOC of production code per PR**.
    - If the estimate exceeds 800 LOC, do NOT proceed with a single large implementation. Instead:
      ```
      ⚠ SIZE LIMIT — estimated ~{N} LOC exceeds the 800 LOC target.

--- a/.claude/skills/create-branch/SKILL.md
+++ b/.claude/skills/create-branch/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: create-branch
+description: Create a new git branch safely — always from a freshly fetched origin/main, never from the currently checked-out branch. Use whenever a new branch is needed (starting an issue, spinning off a skill/config tweak, hotfix, etc.).
+user_invocable: true
+arguments:
+  - name: branch_name
+    description: The name of the new branch (e.g. "32-offchain-event-market-admin")
+    required: true
+---
+
+# Create Branch
+
+Always branch from **remote `origin/main`** — never from whatever branch is currently checked out.
+
+## Why this exists
+
+Branching from the current branch inherits its commits. If that branch holds pre-squash commits of an already-merged PR (common when the PR was squash-merged on GitHub), the new branch will include those commits as "new" work, polluting any PR opened from it. The fix is to always base off `origin/main` directly.
+
+## Steps
+
+1. **Check working tree is clean:**
+   ```bash
+   git status --porcelain
+   ```
+   If there are uncommitted changes, STOP and surface them to the user. Do not silently stash or discard — the user must decide (stash, commit to a dedicated branch, or abandon).
+
+2. **Fetch latest from remote:**
+   ```bash
+   git fetch origin
+   ```
+
+3. **Create the branch directly from `origin/main`:**
+   ```bash
+   git checkout -b {branch_name} origin/main
+   ```
+   This form bypasses the local `main` branch entirely. Never use `git checkout main && git pull && git checkout -b ...` — that path fails silently if you're on an unrelated branch, if local `main` has drifted, or if a squash-merge left old commits reachable from your current HEAD.
+
+4. **Verify the branch is where you expect:**
+   ```bash
+   git log --oneline origin/main..HEAD
+   ```
+   Expect **zero commits** output. If anything appears, the branch was not created from a clean base — stop and investigate before committing anything.
+
+## Anti-patterns (do NOT do these)
+
+- `git checkout -b <name>` (no explicit base) — branches from current HEAD, the exact bug this skill prevents.
+- `git checkout main && git pull && git checkout -b <name>` — assumes local `main` tracks `origin/main` correctly and that you're able to switch to it cleanly. Fails when the working tree is dirty or local `main` has diverged.
+- Branching without fetching first — you may base off stale refs.


### PR DESCRIPTION
## Summary
- New `create-branch` skill that always bases a new branch on a freshly fetched `origin/main` rather than whatever is currently checked out. Motivated by a real incident in this session where branching off the previous task's working branch pulled in pre-squash commits of an already-merged PR, polluting the diff of the next PR.
- `begin-task` step 5 now delegates to `create-branch` instead of the ad-hoc `git checkout main && git pull && git checkout -b` recipe, which failed silently when the current branch wasn't `main` or when the working tree was dirty.
- `begin-task` gains a new step 8: read the parent issue and sibling sub-issues during planning so a sub-task lands with full epic-level context.

## Test plan
- [ ] Invoke `/create-branch <name>` on a clean tree and confirm the branch is created from `origin/main` via `git log --oneline origin/main..HEAD` (expect zero commits).
- [ ] Invoke `/begin-task` on a P2.x sub-issue and confirm parent + sibling issues are read before planning.
- [ ] Verify that any uncommitted changes cause `/create-branch` to surface them to the user rather than silently stash or discard.