### PR TITLE
Off-chain event + market admin endpoints (closes #32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,11 +286,16 @@ not prior implementations, not pattern-matching from similar systems.
 
 ### Pinned reference versions
 
-| Repo | Pinned tag | Purpose |
+| Repo | Pinned ref | Purpose |
 |------|-----------|---------|
 | `Polymarket/clob-client` | `v5.8.2` | TypeScript SDK — auth headers, request signing, REST client |
 | `Polymarket/py-clob-client` | `v0.34.6` | Python SDK — cross-reference for TS |
 | `Polymarket/clob-order-utils` | `main` | Order signing primitives (pin when stable) |
+| `Polymarket/ctf-exchange` | `80cbf37` | Core CTFExchange contract — `Order` EIP-712 struct, fee enforcement, settlement |
+| `Polymarket/neg-risk-ctf-adapter` | `v2.0.0` | Multi-outcome (NegRisk) settlement adapter |
+| `Polymarket/exchange-fee-module` | `v2.0.0` | `FeeModule` + `NegRiskFeeModule` — admin-operated fee refund / withdrawal |
+| `Polymarket/conditional-tokens-contracts` | `v1.0.3` | Conditional token minting, splitting, merging, redemption |
+| `Polymarket/proxy-factories` | `master` | Poly Proxy / Gnosis Safe user-wallet factories (pin when stable) |
 
 Bump these versions intentionally when you decide to upgrade compatibility
 target. Do not drift — if planning work references a newer behavior, pin
@@ -333,11 +338,32 @@ headers, order signing, REST endpoints, response formats):
 ## Contracts (Read-Only Reference)
 
 ABIs consumed from the `contracts` repo via copy. No import dependency.
-- CTFExchange — binary market settlement
-- NegRiskCTFExchange — multi-outcome market settlement
-- ConditionalTokens — token minting, splitting, merging, redemption
-- Fee Module — on-chain fee collection
-- Proxy Factories — user wallet deployment
+Contract source is pinned — see the "Pinned reference versions" table above
+for authoritative repo refs. Fetch via `gh api repos/Polymarket/<repo>/contents/<path>?ref=<pin>`.
+
+- CTFExchange (`Polymarket/ctf-exchange`) — binary market settlement, per-order fee in EIP-712 payload
+- NegRiskCTFAdapter (`Polymarket/neg-risk-ctf-adapter`) — multi-outcome market settlement
+- ConditionalTokens (`Polymarket/conditional-tokens-contracts`) — token minting, splitting, merging, redemption
+- Fee Module (`Polymarket/exchange-fee-module`) — admin-operated fee refund / withdrawal (rates live per-order, not here)
+- Proxy Factories (`Polymarket/proxy-factories`) — user wallet deployment
+
+### Fee model (confirmed against pinned contracts)
+
+- **Fees are per-order, not global.** The `Order` EIP-712 struct in
+  `Polymarket/ctf-exchange` (`src/exchange/libraries/OrderStructs.sol`)
+  includes a `feeRateBps` field; users consent to the rate by signing it.
+- **Hard on-chain cap is `MAX_FEE_RATE_BIPS = 1000` (10%)**, a `pure`
+  constant in `src/exchange/mixins/Fees.sol`. Not admin-settable —
+  changing it requires a contract upgrade. Backend validators must not
+  allow signing orders above this, or the exchange will revert.
+- **Polymarket's REST API exposes `GET /fee-rate?token_id=X`** returning
+  a `base_fee` per market (see `clob-client/src/client.ts`
+  `getFeeRateBps(tokenID)`). Rates are per-token, not a single global value.
+- **No maker/taker split at the protocol level.** Each order carries a
+  single `feeRateBps`. Operator policy decides what rate to stamp onto
+  maker vs taker orders as they are built.
+- **FeeModule is not a rate source** — it's an admin-operated refund /
+  withdrawal utility that sits next to the exchange.
 
 ## Quick Reference
 

--- a/cmd/platform/main.go
+++ b/cmd/platform/main.go
@@ -161,15 +161,23 @@ func run() error {
 	})
 	sessionHandler.RegisterRoutes(mux, limiter.Middleware("auth", ratelimit.KeyByIP))
 
-	// Market admin handlers. Admin middleware stacks JWT authentication, the
-	// admin_wallets check, and the per-admin rate limiter. Order matters:
-	// the limiter sits inside RequireAdmin so only authenticated admin
-	// requests consume bucket tokens.
+	// Admin middleware chain (outermost first):
+	//   Authenticate → RequireAdmin → ratelimit("admin", KeyByUser) → AuditAdminAction → handler
+	// Ordering:
+	//   • Authenticate must run first so RequireAdmin and KeyByUser can read
+	//     the user address from context.
+	//   • The limiter sits inside RequireAdmin so only authenticated admin
+	//     requests consume bucket tokens.
+	//   • AuditAdminAction sits innermost so it observes the final response
+	//     status and can skip logging on non-2xx.
 	adminLimit := limiter.Middleware("admin", ratelimit.KeyByUser)
+	auditAdmin := platformauth.AuditAdminAction(repo, logger)
 	adminMiddleware := func(next http.Handler) http.Handler {
 		return platformauth.Authenticate(jwtMgr)(
 			platformauth.RequireAdmin(repo)(
-				adminLimit(next),
+				adminLimit(
+					auditAdmin(next),
+				),
 			),
 		)
 	}

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -50,6 +50,20 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: admin_audit_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.admin_audit_log (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    admin_address text NOT NULL,
+    method text NOT NULL,
+    path text NOT NULL,
+    status smallint NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
 -- Name: affiliate_earnings; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -114,7 +128,7 @@ CREATE TABLE public.events (
     slug text NOT NULL,
     title text NOT NULL,
     description text DEFAULT ''::text NOT NULL,
-    category_id uuid,
+    category_id uuid NOT NULL,
     event_type smallint NOT NULL,
     resolution_config jsonb DEFAULT '{}'::jsonb NOT NULL,
     status smallint DEFAULT 0 NOT NULL,
@@ -123,6 +137,18 @@ CREATE TABLE public.events (
     featured_sort_order smallint DEFAULT 0 NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: market_fee_rates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.market_fee_rates (
+    market_id uuid NOT NULL,
+    fee_rate_bps integer NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT market_fee_rates_fee_rate_bps_check CHECK (((fee_rate_bps >= 0) AND (fee_rate_bps <= 1000)))
 );
 
 
@@ -287,6 +313,14 @@ CREATE TABLE public.users (
 
 
 --
+-- Name: admin_audit_log admin_audit_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.admin_audit_log
+    ADD CONSTRAINT admin_audit_log_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: affiliate_earnings affiliate_earnings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -348,6 +382,14 @@ ALTER TABLE ONLY public.events
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_slug_unique UNIQUE (slug);
+
+
+--
+-- Name: market_fee_rates market_fee_rates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.market_fee_rates
+    ADD CONSTRAINT market_fee_rates_pkey PRIMARY KEY (market_id);
 
 
 --
@@ -468,6 +510,13 @@ ALTER TABLE ONLY public.users
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_username_unique UNIQUE (username);
+
+
+--
+-- Name: idx_admin_audit_log_admin_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_admin_audit_log_admin_created ON public.admin_audit_log USING btree (admin_address, created_at DESC);
 
 
 --
@@ -659,6 +708,14 @@ ALTER TABLE ONLY public.api_keys
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_category_id_fkey FOREIGN KEY (category_id) REFERENCES public.categories(id);
+
+
+--
+-- Name: market_fee_rates market_fee_rates_market_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.market_fee_rates
+    ADD CONSTRAINT market_fee_rates_market_id_fkey FOREIGN KEY (market_id) REFERENCES public.markets(id) ON DELETE CASCADE;
 
 
 --

--- a/internal/platform/auth/admin_audit.go
+++ b/internal/platform/auth/admin_audit.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"github.com/Shisa-Fosho/services/internal/platform/data"
+	"github.com/Shisa-Fosho/services/internal/shared/httputil"
+)
+
+// AuditAdminAction returns HTTP middleware that records a row in
+// admin_audit_log for every request that passes through it AND produces a
+// successful (2xx) response. Non-2xx responses are intentionally not
+// recorded: 4xx/5xx bypass audit because those requests either failed
+// authorization earlier in the chain (401/403 never reach this middleware)
+// or failed business validation (4xx/5xx) without changing state.
+//
+// Expected chain composition (outermost first):
+//
+//	Authenticate → RequireAdmin → ratelimit("admin", KeyByUser) → AuditAdminAction → handler
+//
+// AuditAdminAction sits innermost so it observes the final response status.
+// Write failures are logged and swallowed — the user-facing request is the
+// source of truth, not the audit trail.
+func AuditAdminAction(repo data.AdminAuditRepository, logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			writer := httputil.NewStatusWriter(w)
+			next.ServeHTTP(writer, r)
+
+			if writer.Code < 200 || writer.Code >= 300 {
+				return
+			}
+
+			adminAddress := AdminAddressFrom(r.Context())
+			if adminAddress == "" {
+				// RequireAdmin should always set this before we're reached;
+				// missing admin implies a misconfigured middleware chain.
+				logger.Warn("audit skipped: no admin address in context",
+					zap.String("path", r.URL.Path),
+				)
+				return
+			}
+
+			action := &data.AdminAuditAction{
+				AdminAddress: adminAddress,
+				Method:       r.Method,
+				Path:         r.URL.Path,
+				Status:       writer.Code,
+			}
+			// Detach from the request context so a canceled request (client
+			// disconnect after the handler returned 2xx) doesn't prevent the
+			// audit write.
+			if err := repo.RecordAdminAction(context.Background(), action); err != nil {
+				logger.Error("recording admin audit entry",
+					zap.String("admin_address", adminAddress),
+					zap.String("method", r.Method),
+					zap.String("path", r.URL.Path),
+					zap.Int("status", writer.Code),
+					zap.Error(err),
+				)
+			}
+		})
+	}
+}

--- a/internal/platform/auth/admin_audit_test.go
+++ b/internal/platform/auth/admin_audit_test.go
@@ -1,0 +1,144 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/Shisa-Fosho/services/internal/platform/data"
+)
+
+// fakeAuditRepo captures audit actions for assertions, with an optional
+// failure injection.
+type fakeAuditRepo struct {
+	mu       sync.Mutex
+	actions  []data.AdminAuditAction
+	writeErr error
+}
+
+func (f *fakeAuditRepo) RecordAdminAction(_ context.Context, action *data.AdminAuditAction) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.actions = append(f.actions, *action)
+	return nil
+}
+
+func (f *fakeAuditRepo) recorded() []data.AdminAuditAction {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]data.AdminAuditAction, len(f.actions))
+	copy(out, f.actions)
+	return out
+}
+
+// runAudit runs the audit middleware around handler with the given admin
+// address in context and returns the response recorder + fake repo.
+func runAudit(t *testing.T, adminAddr string, writeErr error, handler http.Handler, path string) (*httptest.ResponseRecorder, *fakeAuditRepo) {
+	t.Helper()
+	repo := &fakeAuditRepo{writeErr: writeErr}
+	mw := AuditAdminAction(repo, zap.NewNop())(handler)
+
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	if adminAddr != "" {
+		req = req.WithContext(WithAdminAddress(req.Context(), adminAddr))
+	}
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	return rec, repo
+}
+
+func TestAuditAdminAction_Records2xx(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	rec, repo := runAudit(t, "0xadmin", nil, handler, "/admin/events/abc")
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	got := repo.recorded()
+	if len(got) != 1 {
+		t.Fatalf("recorded %d actions, want 1", len(got))
+	}
+	if got[0].AdminAddress != "0xadmin" {
+		t.Errorf("admin_address = %q, want 0xadmin", got[0].AdminAddress)
+	}
+	if got[0].Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", got[0].Method)
+	}
+	if got[0].Path != "/admin/events/abc" {
+		t.Errorf("path = %q, want /admin/events/abc", got[0].Path)
+	}
+	if got[0].Status != http.StatusOK {
+		t.Errorf("status = %d, want 200", got[0].Status)
+	}
+}
+
+func TestAuditAdminAction_Skips4xx(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	})
+	_, repo := runAudit(t, "0xadmin", nil, handler, "/admin/markets/abc/pause")
+	if len(repo.recorded()) != 0 {
+		t.Errorf("expected no audit entries for 409, got %d", len(repo.recorded()))
+	}
+}
+
+func TestAuditAdminAction_Skips5xx(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	_, repo := runAudit(t, "0xadmin", nil, handler, "/admin/events/abc")
+	if len(repo.recorded()) != 0 {
+		t.Errorf("expected no audit entries for 500, got %d", len(repo.recorded()))
+	}
+}
+
+func TestAuditAdminAction_WriteFailureDoesNotAffectResponse(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	rec, _ := runAudit(t, "0xadmin", errors.New("db down"), handler, "/admin/events/abc")
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 even with audit write failure", rec.Code)
+	}
+}
+
+func TestAuditAdminAction_MissingAdminSkipsWrite(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	_, repo := runAudit(t, "", nil, handler, "/admin/events/abc")
+	if len(repo.recorded()) != 0 {
+		t.Errorf("expected no audit entries when admin address is missing, got %d", len(repo.recorded()))
+	}
+}
+
+func TestAuditAdminAction_RecordsImplicit200(t *testing.T) {
+	t.Parallel()
+	// Handler that writes body without calling WriteHeader — stdlib implicitly
+	// sets 200. Ensure the wrapper captures that too.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	_, repo := runAudit(t, "0xadmin", nil, handler, "/admin/events/abc")
+	if len(repo.recorded()) != 1 {
+		t.Fatalf("recorded %d, want 1", len(repo.recorded()))
+	}
+	if repo.recorded()[0].Status != http.StatusOK {
+		t.Errorf("status = %d, want 200 (implicit)", repo.recorded()[0].Status)
+	}
+}

--- a/internal/platform/data/pg_repository.go
+++ b/internal/platform/data/pg_repository.go
@@ -209,3 +209,16 @@ func (repo *PGRepository) IsAdminWallet(ctx context.Context, address string) (bo
 	}
 	return exists, nil
 }
+
+// RecordAdminAction appends a single row to admin_audit_log.
+func (repo *PGRepository) RecordAdminAction(ctx context.Context, action *AdminAuditAction) error {
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO admin_audit_log (admin_address, method, path, status)
+		 VALUES ($1, $2, $3, $4)`,
+		action.AdminAddress, action.Method, action.Path, action.Status,
+	)
+	if err != nil {
+		return fmt.Errorf("recording admin action: %w", err)
+	}
+	return nil
+}

--- a/internal/platform/data/repository.go
+++ b/internal/platform/data/repository.go
@@ -66,3 +66,23 @@ type AdminRepository interface {
 	// lowercase form.
 	IsAdminWallet(ctx context.Context, address string) (bool, error)
 }
+
+// AdminAuditAction describes a single admin HTTP action to be recorded.
+type AdminAuditAction struct {
+	AdminAddress string
+	Method       string
+	Path         string
+	Status       int
+}
+
+// AdminAuditRepository is the narrow write interface consumed by the admin
+// audit middleware. A separate interface keeps the middleware's injection
+// surface minimal and lets tests use a tiny in-memory fake.
+//
+// Implementations must be safe for concurrent use.
+type AdminAuditRepository interface {
+	// RecordAdminAction appends a single audit log entry. Failures should be
+	// returned to the caller; the middleware logs and swallows them so the
+	// underlying request is unaffected.
+	RecordAdminAction(ctx context.Context, action *AdminAuditAction) error
+}

--- a/internal/platform/market/domain.go
+++ b/internal/platform/market/domain.go
@@ -15,6 +15,15 @@ var (
 	ErrInvalidMarket     = errors.New("invalid market")
 	ErrInvalidTransition = errors.New("invalid status transition")
 	ErrDuplicateSlug     = errors.New("duplicate slug")
+	ErrInvalidFeeRate    = errors.New("invalid fee rate")
+)
+
+// Fee-rate bounds (basis points). MaxFeeBps matches the hard-coded on-chain
+// ceiling in Polymarket/ctf-exchange::Fees.sol (MAX_FEE_RATE_BIPS = 1000).
+// Setting a rate above this would cause the exchange to revert on fill.
+const (
+	MinFeeBps = 0
+	MaxFeeBps = 1000 // 10%
 )
 
 // EventType represents the structure of an event (binary or multi-outcome).
@@ -140,7 +149,7 @@ type Event struct {
 	Slug              string          `db:"slug"` // URL-friendly unique identifier.
 	Title             string          `db:"title"`
 	Description       string          `db:"description"`
-	CategoryID        *string         `db:"category_id"` // Nullable FK to categories.
+	CategoryID        string          `db:"category_id"` // FK to categories; required.
 	EventType         EventType       `db:"event_type"`
 	ResolutionConfig  json.RawMessage `db:"resolution_config"` // JSONB — always {} for manual resolution.
 	Status            Status          `db:"status"`
@@ -149,6 +158,42 @@ type Event struct {
 	FeaturedSortOrder int16           `db:"featured_sort_order"`
 	CreatedAt         time.Time       `db:"created_at"`
 	UpdatedAt         time.Time       `db:"updated_at"`
+}
+
+// EventUpdate describes a partial update to an event's editable metadata.
+// Non-nil fields are applied; nil fields are left unchanged. Category can
+// be changed to a different category but never cleared — the column is
+// non-nullable and every event must belong to a category. Slug, event_type,
+// end_date, resolution_config, and status are intentionally not included —
+// those are set at creation or via the dedicated status-transition endpoint.
+type EventUpdate struct {
+	Title             *string
+	Description       *string
+	CategoryID        *string
+	Featured          *bool
+	FeaturedSortOrder *int16
+}
+
+// MarketUpdate describes a partial update to a market's editable metadata.
+// Non-nil fields are applied; nil fields are left unchanged. Slug, token IDs,
+// condition ID, prices, volume, open interest, and status are intentionally
+// not editable via this path.
+//
+//nolint:revive // name mirrors EventUpdate and the external API shape.
+type MarketUpdate struct {
+	Question        *string
+	OutcomeYesLabel *string
+	OutcomeNoLabel  *string
+}
+
+// FeeRate is the operator-set fee rate for a single market in basis points
+// (1 bps = 0.01%). Mirrors Polymarket's model: every order carries a signed
+// `feeRateBps` in its EIP-712 payload; the rate is decided per-market by
+// the operator. See CLAUDE.md "Fee model" for details.
+type FeeRate struct {
+	MarketID   string    `db:"market_id"`
+	FeeRateBps int       `db:"fee_rate_bps"`
+	UpdatedAt  time.Time `db:"updated_at"`
 }
 
 // Market represents a single binary YES/NO prediction market.

--- a/internal/platform/market/handler.go
+++ b/internal/platform/market/handler.go
@@ -3,6 +3,7 @@ package market
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -10,8 +11,6 @@ import (
 )
 
 // Handler implements the platform service's market-domain HTTP endpoints.
-// Admin-only mutation handlers live here; public read handlers will be added
-// alongside them as P3 (Market API) lands.
 type Handler struct {
 	repo   Repository
 	logger *zap.Logger
@@ -22,14 +21,19 @@ func NewHandler(repo Repository, logger *zap.Logger) *Handler {
 	return &Handler{repo: repo, logger: logger}
 }
 
-// RegisterAdminRoutes wires the admin-only category endpoints onto mux. The
-// provided adminMiddleware is expected to stack JWT authentication and the
-// admin-wallet check — see platformauth.Authenticate composed with
-// platformauth.RequireAdmin in cmd/platform/main.go.
+// RegisterAdminRoutes wires the admin-only category, event, and market
+// endpoints onto mux. The provided adminMiddleware is expected to stack
+// JWT authentication and the admin-wallet check — see platformauth.Authenticate
+// composed with platformauth.RequireAdmin in cmd/platform/main.go.
 func (handler *Handler) RegisterAdminRoutes(mux *http.ServeMux, adminMiddleware func(http.Handler) http.Handler) {
 	mux.Handle("POST /admin/categories", adminMiddleware(http.HandlerFunc(handler.createCategory)))
 	mux.Handle("PUT /admin/categories/{id}", adminMiddleware(http.HandlerFunc(handler.updateCategory)))
 	mux.Handle("DELETE /admin/categories/{id}", adminMiddleware(http.HandlerFunc(handler.deleteCategory)))
+	mux.Handle("PUT /admin/events/{id}", adminMiddleware(http.HandlerFunc(handler.updateEvent)))
+	mux.Handle("PUT /admin/markets/{id}", adminMiddleware(http.HandlerFunc(handler.updateMarket)))
+	mux.Handle("POST /admin/markets/{id}/pause", adminMiddleware(http.HandlerFunc(handler.pauseMarket)))
+	mux.Handle("POST /admin/markets/{id}/resume", adminMiddleware(http.HandlerFunc(handler.resumeMarket)))
+	mux.Handle("PUT /admin/markets/{id}/fee-rate", adminMiddleware(http.HandlerFunc(handler.setFeeRate)))
 }
 
 // categoryRequest is the shape both POST and PUT accept.
@@ -121,6 +125,232 @@ func (handler *Handler) deleteCategory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// eventUpdateRequest is the PUT /admin/events/{id} body. All fields are
+// optional; pointer semantics mean a missing field is unchanged. Category
+// can be changed to another category but cannot be cleared — events must
+// always belong to a category.
+type eventUpdateRequest struct {
+	Title             *string `json:"title,omitempty"`
+	Description       *string `json:"description,omitempty"`
+	CategoryID        *string `json:"category_id,omitempty"`
+	Featured          *bool   `json:"featured,omitempty"`
+	FeaturedSortOrder *int16  `json:"featured_sort_order,omitempty"`
+}
+
+// eventResponse is the JSON shape returned for a single event.
+type eventResponse struct {
+	ID                string `json:"id"`
+	Slug              string `json:"slug"`
+	Title             string `json:"title"`
+	Description       string `json:"description"`
+	CategoryID        string `json:"category_id"`
+	EventType         string `json:"event_type"`
+	Status            string `json:"status"`
+	EndDate           string `json:"end_date"`
+	Featured          bool   `json:"featured"`
+	FeaturedSortOrder int16  `json:"featured_sort_order"`
+}
+
+func toEventResponse(event *Event) eventResponse {
+	return eventResponse{
+		ID:                event.ID,
+		Slug:              event.Slug,
+		Title:             event.Title,
+		Description:       event.Description,
+		CategoryID:        event.CategoryID,
+		EventType:         event.EventType.String(),
+		Status:            event.Status.String(),
+		EndDate:           event.EndDate.UTC().Format(time.RFC3339),
+		Featured:          event.Featured,
+		FeaturedSortOrder: event.FeaturedSortOrder,
+	}
+}
+
+func (handler *Handler) updateEvent(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		httputil.ErrorResponse(w, http.StatusBadRequest, "id is required")
+		return
+	}
+
+	var req eventUpdateRequest
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	update := &EventUpdate{
+		Title:             req.Title,
+		Description:       req.Description,
+		CategoryID:        req.CategoryID,
+		Featured:          req.Featured,
+		FeaturedSortOrder: req.FeaturedSortOrder,
+	}
+	updated, err := handler.repo.UpdateEvent(r.Context(), id, update)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidEvent):
+			httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, ErrNotFound):
+			httputil.ErrorResponse(w, http.StatusNotFound, "event not found")
+		default:
+			handler.internalError(w, "updating event", err)
+		}
+		return
+	}
+	_ = httputil.EncodeJSON(w, http.StatusOK, toEventResponse(updated))
+}
+
+// marketUpdateRequest is the PUT /admin/markets/{id} body.
+type marketUpdateRequest struct {
+	Question        *string `json:"question,omitempty"`
+	OutcomeYesLabel *string `json:"outcome_yes_label,omitempty"`
+	OutcomeNoLabel  *string `json:"outcome_no_label,omitempty"`
+}
+
+// marketResponse is the JSON shape returned for a single market.
+type marketResponse struct {
+	ID              string  `json:"id"`
+	Slug            string  `json:"slug"`
+	EventID         *string `json:"event_id"`
+	Question        string  `json:"question"`
+	OutcomeYesLabel string  `json:"outcome_yes_label"`
+	OutcomeNoLabel  string  `json:"outcome_no_label"`
+	Status          string  `json:"status"`
+	PriceYes        int64   `json:"price_yes"`
+	PriceNo         int64   `json:"price_no"`
+	Volume          int64   `json:"volume"`
+	OpenInterest    int64   `json:"open_interest"`
+}
+
+func toMarketResponse(market *Market) marketResponse {
+	return marketResponse{
+		ID:              market.ID,
+		Slug:            market.Slug,
+		EventID:         market.EventID,
+		Question:        market.Question,
+		OutcomeYesLabel: market.OutcomeYesLabel,
+		OutcomeNoLabel:  market.OutcomeNoLabel,
+		Status:          market.Status.String(),
+		PriceYes:        market.PriceYes,
+		PriceNo:         market.PriceNo,
+		Volume:          market.Volume,
+		OpenInterest:    market.OpenInterest,
+	}
+}
+
+func (handler *Handler) updateMarket(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		httputil.ErrorResponse(w, http.StatusBadRequest, "id is required")
+		return
+	}
+
+	var req marketUpdateRequest
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	update := &MarketUpdate{
+		Question:        req.Question,
+		OutcomeYesLabel: req.OutcomeYesLabel,
+		OutcomeNoLabel:  req.OutcomeNoLabel,
+	}
+	updated, err := handler.repo.UpdateMarketMetadata(r.Context(), id, update)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidMarket):
+			httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, ErrNotFound):
+			httputil.ErrorResponse(w, http.StatusNotFound, "market not found")
+		default:
+			handler.internalError(w, "updating market", err)
+		}
+		return
+	}
+	_ = httputil.EncodeJSON(w, http.StatusOK, toMarketResponse(updated))
+}
+
+func (handler *Handler) pauseMarket(w http.ResponseWriter, r *http.Request) {
+	handler.transitionMarket(w, r, StatusPaused)
+}
+
+func (handler *Handler) resumeMarket(w http.ResponseWriter, r *http.Request) {
+	handler.transitionMarket(w, r, StatusActive)
+}
+
+func (handler *Handler) transitionMarket(w http.ResponseWriter, r *http.Request, target Status) {
+	id := r.PathValue("id")
+	if id == "" {
+		httputil.ErrorResponse(w, http.StatusBadRequest, "id is required")
+		return
+	}
+
+	updated, err := handler.repo.UpdateStatus(r.Context(), id, target)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrNotFound):
+			httputil.ErrorResponse(w, http.StatusNotFound, "market not found")
+		case errors.Is(err, ErrInvalidTransition):
+			httputil.ErrorResponse(w, http.StatusConflict, err.Error())
+		default:
+			handler.internalError(w, "transitioning market status", err)
+		}
+		return
+	}
+	_ = httputil.EncodeJSON(w, http.StatusOK, toMarketResponse(updated))
+}
+
+// feeRateRequest is the PUT /admin/markets/{id}/fee-rate body.
+type feeRateRequest struct {
+	FeeRateBps int `json:"fee_rate_bps"`
+}
+
+// feeRateResponse is the JSON shape returned for a market's fee rate.
+type feeRateResponse struct {
+	MarketID   string `json:"market_id"`
+	FeeRateBps int    `json:"fee_rate_bps"`
+	UpdatedAt  string `json:"updated_at"`
+}
+
+func toFeeRateResponse(rate *FeeRate) feeRateResponse {
+	return feeRateResponse{
+		MarketID:   rate.MarketID,
+		FeeRateBps: rate.FeeRateBps,
+		UpdatedAt:  rate.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func (handler *Handler) setFeeRate(w http.ResponseWriter, r *http.Request) {
+	marketID := r.PathValue("id")
+	if marketID == "" {
+		httputil.ErrorResponse(w, http.StatusBadRequest, "id is required")
+		return
+	}
+
+	var req feeRateRequest
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	rate := &FeeRate{MarketID: marketID, FeeRateBps: req.FeeRateBps}
+	updated, err := handler.repo.UpsertFeeRate(r.Context(), rate)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidFeeRate):
+			httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, ErrNotFound):
+			httputil.ErrorResponse(w, http.StatusNotFound, "market not found")
+		default:
+			handler.internalError(w, "upserting fee rate", err)
+		}
+		return
+	}
+	_ = httputil.EncodeJSON(w, http.StatusOK, toFeeRateResponse(updated))
 }
 
 func (handler *Handler) internalError(w http.ResponseWriter, msg string, err error) {

--- a/internal/platform/market/handler_test.go
+++ b/internal/platform/market/handler_test.go
@@ -9,18 +9,23 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 )
 
-// fakeRepo is an in-memory Repository double. Only the category methods are
-// implemented meaningfully — the rest return nil/zero to satisfy the
-// interface. Tests can set hooks to force errors.
+// fakeRepo is an in-memory Repository double for handler tests. The methods
+// exercised by admin handlers are implemented meaningfully; the rest return
+// nil/zero via the embedded Repository interface. Tests can set hooks to
+// force errors.
 type fakeRepo struct {
 	Repository // embed to get default-nil implementations of unused methods
 	byID       map[string]*Category
 	bySlug     map[string]*Category
 	nextID     int
+
+	events  map[string]*Event
+	markets map[string]*Market
 
 	createErr error
 	updateErr error
@@ -29,9 +34,117 @@ type fakeRepo struct {
 
 func newFakeRepo() *fakeRepo {
 	return &fakeRepo{
-		byID:   map[string]*Category{},
-		bySlug: map[string]*Category{},
+		byID:    map[string]*Category{},
+		bySlug:  map[string]*Category{},
+		events:  map[string]*Event{},
+		markets: map[string]*Market{},
 	}
+}
+
+func (f *fakeRepo) putEvent(e *Event) *Event {
+	if e.ID == "" {
+		f.nextID++
+		e.ID = "evt-" + strconv.Itoa(f.nextID)
+	}
+	stored := *e
+	f.events[e.ID] = &stored
+	return &stored
+}
+
+func (f *fakeRepo) putMarket(m *Market) *Market {
+	if m.ID == "" {
+		f.nextID++
+		m.ID = "mkt-" + strconv.Itoa(f.nextID)
+	}
+	stored := *m
+	f.markets[m.ID] = &stored
+	return &stored
+}
+
+func (f *fakeRepo) UpdateEvent(_ context.Context, id string, update *EventUpdate) (*Event, error) {
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	if err := ValidateEventUpdate(update); err != nil {
+		return nil, err
+	}
+	e, ok := f.events[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	if update.Title != nil {
+		e.Title = *update.Title
+	}
+	if update.Description != nil {
+		e.Description = *update.Description
+	}
+	if update.CategoryID != nil {
+		e.CategoryID = *update.CategoryID
+	}
+	if update.Featured != nil {
+		e.Featured = *update.Featured
+	}
+	if update.FeaturedSortOrder != nil {
+		e.FeaturedSortOrder = *update.FeaturedSortOrder
+	}
+	return e, nil
+}
+
+func (f *fakeRepo) UpdateMarketMetadata(_ context.Context, id string, update *MarketUpdate) (*Market, error) {
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	if err := ValidateMarketUpdate(update); err != nil {
+		return nil, err
+	}
+	m, ok := f.markets[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	if update.Question != nil {
+		m.Question = *update.Question
+	}
+	if update.OutcomeYesLabel != nil {
+		m.OutcomeYesLabel = *update.OutcomeYesLabel
+	}
+	if update.OutcomeNoLabel != nil {
+		m.OutcomeNoLabel = *update.OutcomeNoLabel
+	}
+	return m, nil
+}
+
+func (f *fakeRepo) UpdateStatus(_ context.Context, id string, status Status) (*Market, error) {
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	m, ok := f.markets[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	if err := ValidateStatusTransition(m.Status, status); err != nil {
+		return nil, err
+	}
+	m.Status = status
+	return m, nil
+}
+
+func (f *fakeRepo) UpsertFeeRate(_ context.Context, rate *FeeRate) (*FeeRate, error) {
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	if err := ValidateFeeRate(rate); err != nil {
+		return nil, err
+	}
+	if _, ok := f.markets[rate.MarketID]; !ok {
+		return nil, ErrNotFound
+	}
+	stored := &FeeRate{
+		MarketID:   rate.MarketID,
+		FeeRateBps: rate.FeeRateBps,
+		UpdatedAt:  time.Now().UTC(),
+	}
+	out := *stored
+	return &out, nil
 }
 
 func (f *fakeRepo) CreateCategory(_ context.Context, cat *Category) error {
@@ -281,6 +394,281 @@ func TestHandler_DeleteCategory_NotFound(t *testing.T) {
 	rec := doRequest(t, mux, http.MethodDelete, "/admin/categories/missing-id", nil)
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandler_UpdateEvent_Success(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putEvent(&Event{
+		Title: "Original", Description: "desc",
+		CategoryID: "cat-original", Featured: false,
+	})
+	mux := registeredMux(t, repo)
+
+	newTitle := "Updated"
+	featured := true
+	body := mustJSON(t, eventUpdateRequest{Title: &newTitle, Featured: &featured})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/events/"+seed.ID, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want 200", rec.Code, rec.Body.String())
+	}
+	var got eventResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Title != "Updated" {
+		t.Errorf("title = %q, want Updated", got.Title)
+	}
+	if !got.Featured {
+		t.Error("featured = false, want true")
+	}
+	if got.Description != "desc" {
+		t.Errorf("description unexpectedly changed: %q", got.Description)
+	}
+	if got.CategoryID != "cat-original" {
+		t.Errorf("category unexpectedly changed: %q", got.CategoryID)
+	}
+}
+
+func TestHandler_UpdateEvent_ChangeCategory(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putEvent(&Event{Title: "E", CategoryID: "cat-a"})
+	mux := registeredMux(t, repo)
+
+	newCat := "cat-b"
+	body := mustJSON(t, eventUpdateRequest{CategoryID: &newCat})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/events/"+seed.ID, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want 200", rec.Code, rec.Body.String())
+	}
+	var got eventResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.CategoryID != "cat-b" {
+		t.Errorf("category_id = %q, want cat-b", got.CategoryID)
+	}
+}
+
+func TestHandler_UpdateEvent_EmptyCategoryRejected(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putEvent(&Event{Title: "E", CategoryID: "cat-a"})
+	mux := registeredMux(t, repo)
+
+	empty := ""
+	body := mustJSON(t, eventUpdateRequest{CategoryID: &empty})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/events/"+seed.ID, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (category cannot be cleared)", rec.Code)
+	}
+}
+
+func TestHandler_UpdateEvent_NotFound(t *testing.T) {
+	t.Parallel()
+	mux := registeredMux(t, newFakeRepo())
+
+	title := "x"
+	body := mustJSON(t, eventUpdateRequest{Title: &title})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/events/missing-id", body)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandler_UpdateEvent_EmptyBody(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putEvent(&Event{Title: "E"})
+	mux := registeredMux(t, repo)
+
+	body := mustJSON(t, eventUpdateRequest{})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/events/"+seed.ID, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for empty update", rec.Code)
+	}
+}
+
+func TestHandler_UpdateMarket_Success(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putMarket(&Market{
+		Question: "Old?", OutcomeYesLabel: "Yes", OutcomeNoLabel: "No",
+		Status: StatusActive, PriceYes: 50, PriceNo: 50,
+	})
+	mux := registeredMux(t, repo)
+
+	newQ := "New?"
+	body := mustJSON(t, marketUpdateRequest{Question: &newQ})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/markets/"+seed.ID, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want 200", rec.Code, rec.Body.String())
+	}
+	var got marketResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Question != "New?" {
+		t.Errorf("question = %q, want New?", got.Question)
+	}
+	if got.OutcomeYesLabel != "Yes" {
+		t.Errorf("yes label unexpectedly changed: %q", got.OutcomeYesLabel)
+	}
+}
+
+func TestHandler_UpdateMarket_NotFound(t *testing.T) {
+	t.Parallel()
+	mux := registeredMux(t, newFakeRepo())
+
+	q := "x"
+	body := mustJSON(t, marketUpdateRequest{Question: &q})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/markets/missing-id", body)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandler_PauseMarket_Success(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putMarket(&Market{Question: "Q?", Status: StatusActive})
+	mux := registeredMux(t, repo)
+
+	rec := doRequest(t, mux, http.MethodPost, "/admin/markets/"+seed.ID+"/pause", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want 200", rec.Code, rec.Body.String())
+	}
+	var got marketResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != "PAUSED" {
+		t.Errorf("status = %q, want PAUSED", got.Status)
+	}
+}
+
+func TestHandler_ResumeMarket_Success(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putMarket(&Market{Question: "Q?", Status: StatusPaused})
+	mux := registeredMux(t, repo)
+
+	rec := doRequest(t, mux, http.MethodPost, "/admin/markets/"+seed.ID+"/resume", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want 200", rec.Code, rec.Body.String())
+	}
+	var got marketResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != "ACTIVE" {
+		t.Errorf("status = %q, want ACTIVE", got.Status)
+	}
+}
+
+func TestHandler_PauseMarket_InvalidTransition(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putMarket(&Market{Question: "Q?", Status: StatusResolved})
+	mux := registeredMux(t, repo)
+
+	rec := doRequest(t, mux, http.MethodPost, "/admin/markets/"+seed.ID+"/pause", nil)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409", rec.Code)
+	}
+}
+
+func TestHandler_PauseMarket_NotFound(t *testing.T) {
+	t.Parallel()
+	mux := registeredMux(t, newFakeRepo())
+
+	rec := doRequest(t, mux, http.MethodPost, "/admin/markets/missing-id/pause", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandler_SetFeeRate_Success(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putMarket(&Market{Question: "Q?", Status: StatusActive})
+	mux := registeredMux(t, repo)
+
+	body := mustJSON(t, feeRateRequest{FeeRateBps: 50})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/markets/"+seed.ID+"/fee-rate", body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want 200", rec.Code, rec.Body.String())
+	}
+	var got feeRateResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.MarketID != seed.ID {
+		t.Errorf("market_id = %q, want %q", got.MarketID, seed.ID)
+	}
+	if got.FeeRateBps != 50 {
+		t.Errorf("fee_rate_bps = %d, want 50", got.FeeRateBps)
+	}
+}
+
+func TestHandler_SetFeeRate_OutOfRange(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putMarket(&Market{Question: "Q?", Status: StatusActive})
+	mux := registeredMux(t, repo)
+
+	cases := []feeRateRequest{
+		{FeeRateBps: -1},
+		{FeeRateBps: MaxFeeBps + 1},
+		{FeeRateBps: 5000},
+	}
+	for _, tc := range cases {
+		body := mustJSON(t, tc)
+		rec := doRequest(t, mux, http.MethodPut, "/admin/markets/"+seed.ID+"/fee-rate", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("bps=%d: status = %d, want 400", tc.FeeRateBps, rec.Code)
+		}
+	}
+}
+
+func TestHandler_SetFeeRate_MarketNotFound(t *testing.T) {
+	t.Parallel()
+	mux := registeredMux(t, newFakeRepo())
+
+	body := mustJSON(t, feeRateRequest{FeeRateBps: 50})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/markets/missing-id/fee-rate", body)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandler_SetFeeRate_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	seed := repo.putMarket(&Market{Question: "Q?", Status: StatusActive})
+	mux := registeredMux(t, repo)
+
+	rec := doRequest(t, mux, http.MethodPut, "/admin/markets/"+seed.ID+"/fee-rate", []byte("{not valid"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandler_SetFeeRate_RepoError(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	repo.updateErr = errors.New("db down")
+	mux := registeredMux(t, repo)
+
+	body := mustJSON(t, feeRateRequest{FeeRateBps: 50})
+	rec := doRequest(t, mux, http.MethodPut, "/admin/markets/mkt-1/fee-rate", body)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
 	}
 }
 

--- a/internal/platform/market/pg_repository.go
+++ b/internal/platform/market/pg_repository.go
@@ -187,6 +187,40 @@ func (repo *PGRepository) ListEvents(ctx context.Context, statuses []Status) ([]
 	return events, nil
 }
 
+// UpdateEvent applies a partial update to an event's metadata and returns
+// the resulting row. Any argument bound as SQL NULL (i.e. a nil pointer on
+// the EventUpdate) falls through COALESCE to the existing column value, so
+// only fields the admin set are actually changed.
+func (repo *PGRepository) UpdateEvent(ctx context.Context, id string, update *EventUpdate) (*Event, error) {
+	if err := ValidateEventUpdate(update); err != nil {
+		return nil, fmt.Errorf("updating event %s: %w", id, err)
+	}
+	rows, err := repo.pool.Query(ctx,
+		`UPDATE events SET
+		    title               = COALESCE($1, title),
+		    description         = COALESCE($2, description),
+		    category_id         = COALESCE($3, category_id),
+		    featured            = COALESCE($4, featured),
+		    featured_sort_order = COALESCE($5, featured_sort_order),
+		    updated_at          = now()
+		 WHERE id = $6
+		 RETURNING *`,
+		update.Title, update.Description, update.CategoryID,
+		update.Featured, update.FeaturedSortOrder, id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("updating event %s: %w", id, err)
+	}
+	event, err := pgx.CollectOneRow(rows, pgx.RowToAddrOfStructByName[Event])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("updating event %s: %w", id, ErrNotFound)
+		}
+		return nil, fmt.Errorf("updating event %s: %w", id, err)
+	}
+	return event, nil
+}
+
 // CreateMarket persists a new market. Validates input via ValidateMarket
 // before persisting. Returns ErrInvalidMarket for shape violations,
 // ErrDuplicateSlug if the slug already exists.
@@ -288,12 +322,43 @@ func (repo *PGRepository) ListMarketsByEvent(ctx context.Context, eventID string
 	return markets, nil
 }
 
+// UpdateMarketMetadata applies a partial update to a market's editable
+// fields and returns the resulting row. Any argument bound as SQL NULL
+// falls through COALESCE to the existing column value.
+func (repo *PGRepository) UpdateMarketMetadata(ctx context.Context, id string, update *MarketUpdate) (*Market, error) {
+	if err := ValidateMarketUpdate(update); err != nil {
+		return nil, fmt.Errorf("updating market %s: %w", id, err)
+	}
+	rows, err := repo.pool.Query(ctx,
+		`UPDATE markets SET
+		    question          = COALESCE($1, question),
+		    outcome_yes_label = COALESCE($2, outcome_yes_label),
+		    outcome_no_label  = COALESCE($3, outcome_no_label),
+		    updated_at        = now()
+		 WHERE id = $4
+		 RETURNING *`,
+		update.Question, update.OutcomeYesLabel, update.OutcomeNoLabel, id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("updating market %s: %w", id, err)
+	}
+	market, err := pgx.CollectOneRow(rows, pgx.RowToAddrOfStructByName[Market])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("updating market %s: %w", id, ErrNotFound)
+		}
+		return nil, fmt.Errorf("updating market %s: %w", id, err)
+	}
+	return market, nil
+}
+
 // UpdateStatus changes the status of a market. Validates the transition
-// before executing the update.
-func (repo *PGRepository) UpdateStatus(ctx context.Context, id string, status Status) error {
+// inside a transaction holding a row lock, then returns the updated row
+// via UPDATE ... RETURNING — no extra round-trip.
+func (repo *PGRepository) UpdateStatus(ctx context.Context, id string, status Status) (*Market, error) {
 	tx, err := repo.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("updating market status: beginning transaction: %w", err)
+		return nil, fmt.Errorf("updating market status: beginning transaction: %w", err)
 	}
 	defer tx.Rollback(ctx)
 
@@ -303,27 +368,31 @@ func (repo *PGRepository) UpdateStatus(ctx context.Context, id string, status St
 	).Scan(&current)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("updating market %s status: %w", id, ErrNotFound)
+			return nil, fmt.Errorf("updating market %s status: %w", id, ErrNotFound)
 		}
-		return fmt.Errorf("updating market status: reading current: %w", err)
+		return nil, fmt.Errorf("updating market status: reading current: %w", err)
 	}
 
 	if err := ValidateStatusTransition(current, status); err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = tx.Exec(ctx,
-		`UPDATE markets SET status = $1, updated_at = now() WHERE id = $2`,
+	rows, err := tx.Query(ctx,
+		`UPDATE markets SET status = $1, updated_at = now() WHERE id = $2 RETURNING *`,
 		status, id,
 	)
 	if err != nil {
-		return fmt.Errorf("updating market %s status: %w", id, err)
+		return nil, fmt.Errorf("updating market %s status: %w", id, err)
+	}
+	market, err := pgx.CollectOneRow(rows, pgx.RowToAddrOfStructByName[Market])
+	if err != nil {
+		return nil, fmt.Errorf("updating market %s status: %w", id, err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("updating market status: committing: %w", err)
+		return nil, fmt.Errorf("updating market status: committing: %w", err)
 	}
-	return nil
+	return market, nil
 }
 
 // UpdateMarketPrices updates the current prices, volume, and open interest.
@@ -340,6 +409,47 @@ func (repo *PGRepository) UpdateMarketPrices(ctx context.Context, id string, pri
 		return fmt.Errorf("updating market %s prices: %w", id, ErrNotFound)
 	}
 	return nil
+}
+
+// GetFeeRate returns the stored rate for a market, or ErrNotFound if absent.
+func (repo *PGRepository) GetFeeRate(ctx context.Context, marketID string) (*FeeRate, error) {
+	rate := &FeeRate{}
+	err := repo.pool.QueryRow(ctx,
+		`SELECT market_id, fee_rate_bps, updated_at FROM market_fee_rates WHERE market_id = $1`,
+		marketID,
+	).Scan(&rate.MarketID, &rate.FeeRateBps, &rate.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("getting fee rate for market %s: %w", marketID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("getting fee rate for market %s: %w", marketID, err)
+	}
+	return rate, nil
+}
+
+// UpsertFeeRate validates and writes a fee rate for a market. A missing
+// market_id surfaces as ErrNotFound via the FK constraint.
+func (repo *PGRepository) UpsertFeeRate(ctx context.Context, rate *FeeRate) (*FeeRate, error) {
+	if err := ValidateFeeRate(rate); err != nil {
+		return nil, fmt.Errorf("upserting fee rate: %w", err)
+	}
+	result := &FeeRate{}
+	err := repo.pool.QueryRow(ctx,
+		`INSERT INTO market_fee_rates (market_id, fee_rate_bps, updated_at)
+		 VALUES ($1, $2, now())
+		 ON CONFLICT (market_id) DO UPDATE SET
+		     fee_rate_bps = EXCLUDED.fee_rate_bps,
+		     updated_at = now()
+		 RETURNING market_id, fee_rate_bps, updated_at`,
+		rate.MarketID, rate.FeeRateBps,
+	).Scan(&result.MarketID, &result.FeeRateBps, &result.UpdatedAt)
+	if err != nil {
+		if postgres.IsForeignKeyViolation(err) {
+			return nil, fmt.Errorf("upserting fee rate for market %s: %w", rate.MarketID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("upserting fee rate for market %s: %w", rate.MarketID, err)
+	}
+	return result, nil
 }
 
 // statusSlice converts Status values to int16 for pgx ANY() binding.

--- a/internal/platform/market/pg_repository_test.go
+++ b/internal/platform/market/pg_repository_test.go
@@ -19,10 +19,22 @@ func cleanTables(t *testing.T, pool *pgxpool.Pool) {
 	ctx := context.Background()
 	// Truncate in reverse FK order.
 	_, err := pool.Exec(ctx,
-		`TRUNCATE markets, events, categories CASCADE`)
+		`TRUNCATE market_fee_rates, markets, events, categories CASCADE`)
 	if err != nil {
 		t.Fatalf("cleaning tables: %v", err)
 	}
+}
+
+// seedCategory creates a category with a unique slug and returns its ID.
+// Events require a non-null category_id, so every event-creating test needs
+// a fixture like this.
+func seedCategory(t *testing.T, repo *PGRepository, slug string) string {
+	t.Helper()
+	cat := &Category{Name: slug, Slug: slug}
+	if err := repo.CreateCategory(context.Background(), cat); err != nil {
+		t.Fatalf("seeding category %q: %v", slug, err)
+	}
+	return cat.ID
 }
 
 func TestPGRepository_CreateAndGetCategory(t *testing.T) {
@@ -191,10 +203,12 @@ func TestPGRepository_CreateAndGetEvent(t *testing.T) {
 	repo := NewPGRepository(pool)
 	ctx := context.Background()
 
+	catID := seedCategory(t, repo, "politics")
 	event := &Event{
 		Slug:             "us-election-2024",
 		Title:            "2024 US Presidential Election",
 		Description:      "Who will win?",
+		CategoryID:       catID,
 		EventType:        EventTypeBinary,
 		ResolutionConfig: json.RawMessage(`{}`),
 		Status:           StatusActive,
@@ -230,9 +244,11 @@ func TestPGRepository_GetEventBySlug(t *testing.T) {
 	repo := NewPGRepository(pool)
 	ctx := context.Background()
 
+	catID := seedCategory(t, repo, "general")
 	event := &Event{
 		Slug:             "slug-lookup-test",
 		Title:            "Slug Lookup",
+		CategoryID:       catID,
 		EventType:        EventTypeBinary,
 		ResolutionConfig: json.RawMessage(`{}`),
 		Status:           StatusActive,
@@ -257,9 +273,11 @@ func TestPGRepository_CreateEvent_DuplicateSlug(t *testing.T) {
 	repo := NewPGRepository(pool)
 	ctx := context.Background()
 
+	catID := seedCategory(t, repo, "general")
 	event := &Event{
 		Slug:             "dup-event",
 		Title:            "Original",
+		CategoryID:       catID,
 		EventType:        EventTypeBinary,
 		ResolutionConfig: json.RawMessage(`{}`),
 		Status:           StatusActive,
@@ -294,6 +312,7 @@ func TestPGRepository_ListEvents_StatusFilter(t *testing.T) {
 	repo := NewPGRepository(pool)
 	ctx := context.Background()
 
+	catID := seedCategory(t, repo, "general")
 	for _, slug := range []string{"active-event", "paused-event"} {
 		status := StatusActive
 		if slug == "paused-event" {
@@ -302,6 +321,7 @@ func TestPGRepository_ListEvents_StatusFilter(t *testing.T) {
 		event := &Event{
 			Slug:             slug,
 			Title:            slug,
+			CategoryID:       catID,
 			EventType:        EventTypeBinary,
 			ResolutionConfig: json.RawMessage(`{}`),
 			Status:           status,
@@ -427,8 +447,12 @@ func TestPGRepository_UpdateStatus(t *testing.T) {
 	}
 	id := markets[0].ID
 
-	if err := repo.UpdateStatus(ctx, id, StatusPaused); err != nil {
+	updated, err := repo.UpdateStatus(ctx, id, StatusPaused)
+	if err != nil {
 		t.Fatalf("updating status to paused: %v", err)
+	}
+	if updated.Status != StatusPaused {
+		t.Errorf("returned market status = %s, want %s", updated.Status, StatusPaused)
 	}
 
 	got, err := repo.GetMarket(ctx, id)
@@ -465,12 +489,12 @@ func TestPGRepository_UpdateStatus_InvalidTransition(t *testing.T) {
 	// Resolve the market first.
 	markets, _ := repo.ListMarkets(ctx, nil)
 	id := markets[0].ID
-	if err := repo.UpdateStatus(ctx, id, StatusResolved); err != nil {
+	if _, err := repo.UpdateStatus(ctx, id, StatusResolved); err != nil {
 		t.Fatalf("resolving market: %v", err)
 	}
 
 	// Try to go back to active — should fail.
-	err := repo.UpdateStatus(ctx, id, StatusActive)
+	_, err := repo.UpdateStatus(ctx, id, StatusActive)
 	if !errors.Is(err, ErrInvalidTransition) {
 		t.Errorf("expected ErrInvalidTransition, got: %v", err)
 	}
@@ -532,5 +556,254 @@ func TestPGRepository_UpdateMarketPrices_NotFound(t *testing.T) {
 	err := repo.UpdateMarketPrices(ctx, "00000000-0000-0000-0000-000000000000", 50, 50, 0, 0)
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestPGRepository_UpdateEvent(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	origCat := seedCategory(t, repo, "sports")
+	newCat := seedCategory(t, repo, "politics")
+
+	event := &Event{
+		Slug:             "updatable-event",
+		Title:            "Original",
+		Description:      "Original description",
+		CategoryID:       origCat,
+		EventType:        EventTypeBinary,
+		ResolutionConfig: json.RawMessage(`{}`),
+		Status:           StatusActive,
+		EndDate:          time.Now().Add(30 * 24 * time.Hour),
+	}
+	if err := repo.CreateEvent(ctx, event); err != nil {
+		t.Fatalf("creating event: %v", err)
+	}
+	events, _ := repo.ListEvents(ctx, nil)
+	id := events[0].ID
+
+	newTitle := "Updated Title"
+	featured := true
+	got, err := repo.UpdateEvent(ctx, id, &EventUpdate{
+		Title:      &newTitle,
+		CategoryID: &newCat,
+		Featured:   &featured,
+	})
+	if err != nil {
+		t.Fatalf("updating event: %v", err)
+	}
+	if got.Title != newTitle {
+		t.Errorf("title = %q, want %q", got.Title, newTitle)
+	}
+	if got.Description != "Original description" {
+		t.Errorf("description unexpectedly changed: %q", got.Description)
+	}
+	if got.CategoryID != newCat {
+		t.Errorf("category_id = %q, want %q", got.CategoryID, newCat)
+	}
+	if !got.Featured {
+		t.Error("featured = false, want true")
+	}
+
+	// Partial update: only title changes; category remains newCat.
+	newerTitle := "Another Update"
+	unchanged, err := repo.UpdateEvent(ctx, id, &EventUpdate{Title: &newerTitle})
+	if err != nil {
+		t.Fatalf("partial update: %v", err)
+	}
+	if unchanged.Title != newerTitle {
+		t.Errorf("title = %q, want %q", unchanged.Title, newerTitle)
+	}
+	if unchanged.CategoryID != newCat {
+		t.Errorf("category changed during partial update: %q, want %q", unchanged.CategoryID, newCat)
+	}
+}
+
+func TestPGRepository_UpdateEvent_NotFound(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	title := "x"
+	_, err := repo.UpdateEvent(ctx, "00000000-0000-0000-0000-000000000000", &EventUpdate{Title: &title})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestPGRepository_UpdateMarketMetadata(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	market := &Market{
+		Slug:            "metadata-test",
+		Question:        "Original?",
+		OutcomeYesLabel: "Yes",
+		OutcomeNoLabel:  "No",
+		TokenIDYes:      "ty",
+		TokenIDNo:       "tn",
+		ConditionID:     "c1",
+		Status:          StatusActive,
+		PriceYes:        50,
+		PriceNo:         50,
+	}
+	if err := repo.CreateMarket(ctx, market); err != nil {
+		t.Fatalf("creating market: %v", err)
+	}
+	markets, _ := repo.ListMarkets(ctx, nil)
+	id := markets[0].ID
+
+	newQuestion := "Updated?"
+	newYes := "Absolutely"
+	got, err := repo.UpdateMarketMetadata(ctx, id, &MarketUpdate{
+		Question:        &newQuestion,
+		OutcomeYesLabel: &newYes,
+	})
+	if err != nil {
+		t.Fatalf("updating market metadata: %v", err)
+	}
+	if got.Question != newQuestion {
+		t.Errorf("question = %q, want %q", got.Question, newQuestion)
+	}
+	if got.OutcomeYesLabel != newYes {
+		t.Errorf("yes label = %q, want %q", got.OutcomeYesLabel, newYes)
+	}
+	if got.OutcomeNoLabel != "No" {
+		t.Errorf("no label unexpectedly changed: %q", got.OutcomeNoLabel)
+	}
+	if got.Status != StatusActive {
+		t.Errorf("status unexpectedly changed: %s", got.Status)
+	}
+}
+
+func TestPGRepository_UpdateMarketMetadata_NotFound(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	q := "x"
+	_, err := repo.UpdateMarketMetadata(ctx, "00000000-0000-0000-0000-000000000000", &MarketUpdate{Question: &q})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+// seedMarketForFeeRate creates the category+market fixture chain that
+// market_fee_rates' FK requires, and returns the market id.
+func seedMarketForFeeRate(t *testing.T, repo *PGRepository, slug string) string {
+	t.Helper()
+	ctx := context.Background()
+	catID := seedCategory(t, repo, slug+"-cat")
+	event := &Event{
+		Slug:             slug + "-event",
+		Title:            slug,
+		CategoryID:       catID,
+		EventType:        EventTypeBinary,
+		ResolutionConfig: json.RawMessage(`{}`),
+		Status:           StatusActive,
+		EndDate:          time.Now().Add(30 * 24 * time.Hour),
+	}
+	if err := repo.CreateEvent(ctx, event); err != nil {
+		t.Fatalf("seeding event: %v", err)
+	}
+	mkt := &Market{
+		Slug:            slug,
+		Question:        "Q?",
+		OutcomeYesLabel: "Yes",
+		OutcomeNoLabel:  "No",
+		TokenIDYes:      "ty-" + slug,
+		TokenIDNo:       "tn-" + slug,
+		ConditionID:     "c-" + slug,
+		Status:          StatusActive,
+		PriceYes:        50,
+		PriceNo:         50,
+	}
+	if err := repo.CreateMarket(ctx, mkt); err != nil {
+		t.Fatalf("seeding market: %v", err)
+	}
+	markets, err := repo.ListMarkets(ctx, nil)
+	if err != nil || len(markets) == 0 {
+		t.Fatalf("listing markets: %v", err)
+	}
+	return markets[0].ID
+}
+
+func TestPGRepository_GetFeeRate_NotFound(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.GetFeeRate(ctx, "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestPGRepository_UpsertFeeRate_InsertThenUpdate(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	marketID := seedMarketForFeeRate(t, repo, "fee-upsert")
+
+	got, err := repo.UpsertFeeRate(ctx, &FeeRate{MarketID: marketID, FeeRateBps: 25})
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if got.FeeRateBps != 25 {
+		t.Errorf("fee_rate_bps = %d, want 25", got.FeeRateBps)
+	}
+
+	got, err = repo.UpsertFeeRate(ctx, &FeeRate{MarketID: marketID, FeeRateBps: 75})
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if got.FeeRateBps != 75 {
+		t.Errorf("fee_rate_bps = %d, want 75", got.FeeRateBps)
+	}
+
+	read, err := repo.GetFeeRate(ctx, marketID)
+	if err != nil {
+		t.Fatalf("get rate: %v", err)
+	}
+	if read.FeeRateBps != 75 {
+		t.Errorf("read fee_rate_bps = %d, want 75", read.FeeRateBps)
+	}
+}
+
+func TestPGRepository_UpsertFeeRate_MarketNotFound(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.UpsertFeeRate(ctx, &FeeRate{
+		MarketID:   "00000000-0000-0000-0000-000000000000",
+		FeeRateBps: 10,
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestPGRepository_UpsertFeeRate_Invalid(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	marketID := seedMarketForFeeRate(t, repo, "fee-invalid")
+
+	_, err := repo.UpsertFeeRate(ctx, &FeeRate{MarketID: marketID, FeeRateBps: -1})
+	if !errors.Is(err, ErrInvalidFeeRate) {
+		t.Errorf("expected ErrInvalidFeeRate, got: %v", err)
 	}
 }

--- a/internal/platform/market/repository.go
+++ b/internal/platform/market/repository.go
@@ -40,6 +40,13 @@ type Repository interface {
 	// is empty, all events are returned.
 	ListEvents(ctx context.Context, statuses []Status) ([]*Event, error)
 
+	// UpdateEvent applies a partial update to an event's editable metadata
+	// and returns the resulting row. Returns ErrNotFound if the id doesn't
+	// match a row, or ErrInvalidEvent if the update is empty/invalid. Slug,
+	// event type, end date, resolution config, and status are not mutable
+	// through this path.
+	UpdateEvent(ctx context.Context, id string, update *EventUpdate) (*Event, error)
+
 	// CreateMarket persists a new market. Validates input via ValidateMarket
 	// before persisting. Returns ErrInvalidMarket for shape violations,
 	// ErrDuplicateSlug if the slug already exists.
@@ -58,12 +65,29 @@ type Repository interface {
 	// ListMarketsByEvent returns all markets belonging to an event.
 	ListMarketsByEvent(ctx context.Context, eventID string) ([]*Market, error)
 
-	// UpdateStatus changes the status of a market. Returns
-	// ErrInvalidTransition if the transition is not allowed, or
-	// ErrNotFound if the market does not exist.
-	UpdateStatus(ctx context.Context, id string, status Status) error
+	// UpdateMarketMetadata applies a partial update to a market's editable
+	// fields (question, outcome labels) and returns the resulting row.
+	// Returns ErrNotFound if the id doesn't match a row, or ErrInvalidMarket
+	// if the update is empty/invalid. Slug, token IDs, condition ID, prices,
+	// and status are not mutable through this path.
+	UpdateMarketMetadata(ctx context.Context, id string, update *MarketUpdate) (*Market, error)
+
+	// UpdateStatus changes the status of a market and returns the updated
+	// row. Returns ErrInvalidTransition if the transition is not allowed,
+	// or ErrNotFound if the market does not exist.
+	UpdateStatus(ctx context.Context, id string, status Status) (*Market, error)
 
 	// UpdateMarketPrices updates the current prices, volume, and open interest
 	// for a market. Returns ErrNotFound if the market does not exist.
 	UpdateMarketPrices(ctx context.Context, id string, priceYes, priceNo, volume, openInterest int64) error
+
+	// GetFeeRate returns the stored fee rate for a market. Returns
+	// ErrNotFound if no rate has been set — callers typically treat that
+	// as "use the platform default" (currently 0 bps).
+	GetFeeRate(ctx context.Context, marketID string) (*FeeRate, error)
+
+	// UpsertFeeRate validates and writes a market's fee rate, returning
+	// the resulting row. Returns ErrInvalidFeeRate for shape violations
+	// and ErrNotFound if market_id does not reference an existing market.
+	UpsertFeeRate(ctx context.Context, rate *FeeRate) (*FeeRate, error)
 }

--- a/internal/platform/market/validate.go
+++ b/internal/platform/market/validate.go
@@ -17,6 +17,10 @@ func ValidateEvent(event *Event, now time.Time) error {
 		return fmt.Errorf("title is required: %w", ErrInvalidEvent)
 	}
 
+	if event.CategoryID == "" {
+		return fmt.Errorf("category_id is required: %w", ErrInvalidEvent)
+	}
+
 	if !event.EndDate.After(now) {
 		return fmt.Errorf("end date must be in the future: %w", ErrInvalidEvent)
 	}
@@ -75,6 +79,69 @@ func ValidateMarket(market *Market) error {
 func ValidateStatusTransition(from, to Status) error {
 	if !ValidTransition(from, to) {
 		return fmt.Errorf("cannot transition from %s to %s: %w", from, to, ErrInvalidTransition)
+	}
+	return nil
+}
+
+// ValidateEventUpdate checks a partial event update for shape violations.
+// Enforces non-empty strings when a field is being set, and a non-negative
+// featured_sort_order. Returns ErrInvalidEvent wrapping a descriptive message.
+func ValidateEventUpdate(update *EventUpdate) error {
+	if update == nil ||
+		(update.Title == nil &&
+			update.Description == nil &&
+			update.CategoryID == nil &&
+			update.Featured == nil &&
+			update.FeaturedSortOrder == nil) {
+		return fmt.Errorf("no fields to update: %w", ErrInvalidEvent)
+	}
+	if update.Title != nil && *update.Title == "" {
+		return fmt.Errorf("title cannot be empty: %w", ErrInvalidEvent)
+	}
+	if update.CategoryID != nil && *update.CategoryID == "" {
+		return fmt.Errorf("category_id cannot be empty: %w", ErrInvalidEvent)
+	}
+	if update.FeaturedSortOrder != nil && *update.FeaturedSortOrder < 0 {
+		return fmt.Errorf("featured_sort_order must be non-negative: %w", ErrInvalidEvent)
+	}
+	return nil
+}
+
+// ValidateFeeRate checks that the market id is non-empty and the fee rate
+// is within [MinFeeBps, MaxFeeBps]. Returns ErrInvalidFeeRate wrapping a
+// descriptive message on failure.
+func ValidateFeeRate(rate *FeeRate) error {
+	if rate == nil {
+		return fmt.Errorf("rate is nil: %w", ErrInvalidFeeRate)
+	}
+	if rate.MarketID == "" {
+		return fmt.Errorf("market_id is required: %w", ErrInvalidFeeRate)
+	}
+	if rate.FeeRateBps < MinFeeBps || rate.FeeRateBps > MaxFeeBps {
+		return fmt.Errorf("fee_rate_bps %d out of range [%d, %d]: %w",
+			rate.FeeRateBps, MinFeeBps, MaxFeeBps, ErrInvalidFeeRate)
+	}
+	return nil
+}
+
+// ValidateMarketUpdate checks a partial market update for shape violations.
+// Enforces non-empty strings when a field is being set. Returns
+// ErrInvalidMarket wrapping a descriptive message.
+func ValidateMarketUpdate(update *MarketUpdate) error {
+	if update == nil ||
+		(update.Question == nil &&
+			update.OutcomeYesLabel == nil &&
+			update.OutcomeNoLabel == nil) {
+		return fmt.Errorf("no fields to update: %w", ErrInvalidMarket)
+	}
+	if update.Question != nil && *update.Question == "" {
+		return fmt.Errorf("question cannot be empty: %w", ErrInvalidMarket)
+	}
+	if update.OutcomeYesLabel != nil && *update.OutcomeYesLabel == "" {
+		return fmt.Errorf("outcome_yes_label cannot be empty: %w", ErrInvalidMarket)
+	}
+	if update.OutcomeNoLabel != nil && *update.OutcomeNoLabel == "" {
+		return fmt.Errorf("outcome_no_label cannot be empty: %w", ErrInvalidMarket)
 	}
 	return nil
 }

--- a/internal/platform/market/validate_test.go
+++ b/internal/platform/market/validate_test.go
@@ -12,6 +12,7 @@ func validEvent() *Event {
 		Slug:             "test-event",
 		Title:            "Test Event",
 		Description:      "A test event.",
+		CategoryID:       "550e8400-e29b-41d4-a716-446655440000",
 		EventType:        EventTypeBinary,
 		ResolutionConfig: json.RawMessage(`{}`),
 		Status:           StatusActive,
@@ -58,12 +59,9 @@ func TestValidateEvent(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "with category ID is valid",
-			modify: func(event *Event) {
-				catID := "550e8400-e29b-41d4-a716-446655440000"
-				event.CategoryID = &catID
-			},
-			wantErr: false,
+			name:    "empty category id",
+			modify:  func(event *Event) { event.CategoryID = "" },
+			wantErr: true,
 		},
 	}
 
@@ -178,6 +176,124 @@ func TestValidateMarket(t *testing.T) {
 			}
 			if tt.wantErr && err != nil && !errors.Is(err, ErrInvalidMarket) {
 				t.Errorf("expected ErrInvalidMarket, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateEventUpdate(t *testing.T) {
+	t.Parallel()
+
+	title := "New"
+	empty := ""
+	catID := "550e8400-e29b-41d4-a716-446655440000"
+	featured := true
+	validOrder := int16(10)
+	negOrder := int16(-1)
+
+	tests := []struct {
+		name    string
+		update  *EventUpdate
+		wantErr bool
+	}{
+		{"nil update", nil, true},
+		{"all fields nil is empty", &EventUpdate{}, true},
+		{"title only is valid", &EventUpdate{Title: &title}, false},
+		{"featured only is valid", &EventUpdate{Featured: &featured}, false},
+		{"set category with uuid is valid", &EventUpdate{CategoryID: &catID}, false},
+		{"empty title is invalid", &EventUpdate{Title: &empty}, true},
+		{"empty category id is invalid", &EventUpdate{CategoryID: &empty}, true},
+		{"negative sort order is invalid", &EventUpdate{FeaturedSortOrder: &negOrder}, true},
+		{"valid sort order", &EventUpdate{FeaturedSortOrder: &validOrder}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateEventUpdate(tt.update)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && !errors.Is(err, ErrInvalidEvent) {
+				t.Errorf("expected ErrInvalidEvent, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateMarketUpdate(t *testing.T) {
+	t.Parallel()
+
+	question := "Will it?"
+	yes := "YES"
+	no := "NO"
+	empty := ""
+
+	tests := []struct {
+		name    string
+		update  *MarketUpdate
+		wantErr bool
+	}{
+		{"nil update", nil, true},
+		{"empty update", &MarketUpdate{}, true},
+		{"question only is valid", &MarketUpdate{Question: &question}, false},
+		{"yes label only is valid", &MarketUpdate{OutcomeYesLabel: &yes}, false},
+		{"no label only is valid", &MarketUpdate{OutcomeNoLabel: &no}, false},
+		{"empty question is invalid", &MarketUpdate{Question: &empty}, true},
+		{"empty yes label is invalid", &MarketUpdate{OutcomeYesLabel: &empty}, true},
+		{"empty no label is invalid", &MarketUpdate{OutcomeNoLabel: &empty}, true},
+		{"all fields set is valid", &MarketUpdate{Question: &question, OutcomeYesLabel: &yes, OutcomeNoLabel: &no}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateMarketUpdate(tt.update)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && !errors.Is(err, ErrInvalidMarket) {
+				t.Errorf("expected ErrInvalidMarket, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateFeeRate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rate    *FeeRate
+		wantErr bool
+	}{
+		{"nil rate", nil, true},
+		{"missing market id", &FeeRate{FeeRateBps: 10}, true},
+		{"zero is valid", &FeeRate{MarketID: "m1", FeeRateBps: 0}, false},
+		{"max is valid", &FeeRate{MarketID: "m1", FeeRateBps: MaxFeeBps}, false},
+		{"mid range valid", &FeeRate{MarketID: "m1", FeeRateBps: 25}, false},
+		{"negative bps", &FeeRate{MarketID: "m1", FeeRateBps: -1}, true},
+		{"above on-chain cap", &FeeRate{MarketID: "m1", FeeRateBps: MaxFeeBps + 1}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateFeeRate(tt.rate)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && !errors.Is(err, ErrInvalidFeeRate) {
+				t.Errorf("expected ErrInvalidFeeRate, got: %v", err)
 			}
 		})
 	}

--- a/internal/shared/httputil/middleware.go
+++ b/internal/shared/httputil/middleware.go
@@ -26,24 +26,37 @@ func RequestID(next http.Handler) http.Handler {
 	})
 }
 
-// statusWriter wraps http.ResponseWriter to capture the status code.
-type statusWriter struct {
+// StatusWriter wraps http.ResponseWriter to capture the status code for
+// middleware that observes response outcomes (logging, audit trails, etc.).
+// Zero value is usable with Code defaulting to 0 until the handler writes;
+// use NewStatusWriter to get the 200-default wrapper.
+type StatusWriter struct {
 	http.ResponseWriter
-	code    int
+	Code    int
 	written bool
 }
 
-func (writer *statusWriter) WriteHeader(code int) {
+// NewStatusWriter wraps w and defaults Code to 200 (matching stdlib behavior
+// when a handler writes a body without calling WriteHeader).
+func NewStatusWriter(w http.ResponseWriter) *StatusWriter {
+	return &StatusWriter{ResponseWriter: w, Code: http.StatusOK}
+}
+
+// WriteHeader captures the status code on the first call and forwards to
+// the wrapped ResponseWriter.
+func (writer *StatusWriter) WriteHeader(code int) {
 	if !writer.written {
-		writer.code = code
+		writer.Code = code
 		writer.written = true
 	}
 	writer.ResponseWriter.WriteHeader(code)
 }
 
-func (writer *statusWriter) Write(data []byte) (int, error) {
+// Write forwards to the wrapped ResponseWriter, defaulting Code to 200 if
+// the handler wrote a body without first calling WriteHeader.
+func (writer *StatusWriter) Write(data []byte) (int, error) {
 	if !writer.written {
-		writer.code = http.StatusOK
+		writer.Code = http.StatusOK
 		writer.written = true
 	}
 	return writer.ResponseWriter.Write(data)
@@ -55,14 +68,14 @@ func Logging(logger *zap.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
-			writer := &statusWriter{ResponseWriter: w, code: http.StatusOK}
+			writer := NewStatusWriter(w)
 
 			next.ServeHTTP(writer, r)
 
 			logger.Info("http request",
 				zap.String("method", r.Method),
 				zap.String("path", r.URL.Path),
-				zap.Int("status", writer.code),
+				zap.Int("status", writer.Code),
 				zap.Duration("duration", time.Since(start)),
 				zap.String("request_id", observability.RequestIDFrom(r.Context())),
 			)

--- a/internal/shared/postgres/errors.go
+++ b/internal/shared/postgres/errors.go
@@ -23,3 +23,12 @@ func IsCheckViolation(err error) bool {
 	}
 	return false
 }
+
+// IsForeignKeyViolation returns true if the error is a PostgreSQL foreign key constraint violation.
+func IsForeignKeyViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23503" // foreign_key_violation
+	}
+	return false
+}

--- a/migrations/platform/000011_create_market_fee_rates.down.sql
+++ b/migrations/platform/000011_create_market_fee_rates.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS market_fee_rates;

--- a/migrations/platform/000011_create_market_fee_rates.up.sql
+++ b/migrations/platform/000011_create_market_fee_rates.up.sql
@@ -1,0 +1,12 @@
+-- Per-market fee rates, aligned with Polymarket's model
+-- (Polymarket/ctf-exchange — Order.feeRateBps is signed into every EIP-712
+-- order payload; rates are decided per-market by the operator).
+--
+-- Bounds mirror the on-chain cap (MAX_FEE_RATE_BIPS = 1000 in
+-- src/exchange/mixins/Fees.sol). Above that the exchange reverts, so this
+-- CHECK is a safety net for admins setting impossible rates.
+CREATE TABLE IF NOT EXISTS market_fee_rates (
+    market_id     UUID        PRIMARY KEY REFERENCES markets(id) ON DELETE CASCADE,
+    fee_rate_bps  INTEGER     NOT NULL CHECK (fee_rate_bps BETWEEN 0 AND 1000),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/migrations/platform/000012_create_admin_audit_log.down.sql
+++ b/migrations/platform/000012_create_admin_audit_log.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS admin_audit_log;

--- a/migrations/platform/000012_create_admin_audit_log.up.sql
+++ b/migrations/platform/000012_create_admin_audit_log.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS admin_audit_log (
+    id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    admin_address  TEXT        NOT NULL,
+    method         TEXT        NOT NULL,
+    path           TEXT        NOT NULL,
+    status         SMALLINT    NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_admin_audit_log_admin_created
+    ON admin_audit_log (admin_address, created_at DESC);

--- a/migrations/platform/000013_events_require_category.down.sql
+++ b/migrations/platform/000013_events_require_category.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ALTER COLUMN category_id DROP NOT NULL;

--- a/migrations/platform/000013_events_require_category.up.sql
+++ b/migrations/platform/000013_events_require_category.up.sql
@@ -1,0 +1,5 @@
+-- Category is now a required relationship on every event. Any pre-existing
+-- row with a null category_id is invalid under the new model and must be
+-- fixed or removed manually before this migration runs; we do not backfill
+-- silently.
+ALTER TABLE events ALTER COLUMN category_id SET NOT NULL;


### PR DESCRIPTION
## Summary

- **Admin mutation endpoints** — `PUT /admin/events/{id}`, `PUT /admin/markets/{id}`, `POST /admin/markets/{id}/pause|resume`, `PUT /admin/markets/{id}/fee-rate`. Partial-update semantics for metadata (pointer fields, nil = don't touch); pause/resume use the existing `ValidateStatusTransition` state machine.
- **Per-market fee policy** — `market_fee_rates` table keyed on `market_id`, matching Polymarket's model (fees signed into each order's EIP-712 payload, no maker/taker split at the protocol level, hard 10% ceiling from `ctf-exchange::Fees.sol`). Contract repos now pinned in CLAUDE.md.
- **Admin audit trail** — new `auth.AuditAdminAction` middleware records every 2xx admin response to `admin_audit_log` via `data.AdminAuditRepository`. Wraps innermost in the admin chain so it observes the final status. Write failures log but don't fail the request.
- **Category is now required on events** — migration 000013 sets `events.category_id NOT NULL`. Category can be changed via `PUT` but never cleared.
- **Refactor** — `httputil.statusWriter` exported as `StatusWriter` (now shared by `Logging` and `AuditAdminAction`); `postgres.IsForeignKeyViolation` added alongside existing helpers.

## Test plan

- [ ] `make lint && go test ./... -count=1 && go build ./...` — all green locally
- [ ] Manual: `curl -X PUT $PLATFORM/admin/events/<id>` with a valid admin JWT returns 200 and updated body
- [ ] Manual: `POST /admin/markets/<id>/pause` on an active market → 200; pause again → 409
- [ ] Manual: `PUT /admin/markets/<id>/fee-rate` with `fee_rate_bps > 1000` → 400
- [ ] Manual: admin endpoints return 401 without JWT, 403 with non-admin JWT
- [ ] Manual: confirm `admin_audit_log` row exists after each successful admin mutation; confirm no row for 401/403/4xx cases
- [ ] Migrations 000011–000013 apply cleanly from a fresh DB