### PR TITLE
Consolidate Trade fee fields: MakerFee + TakerFee → Fee (closes #70)

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -289,8 +289,7 @@ CREATE TABLE public.trades (
     market_id uuid NOT NULL,
     price bigint NOT NULL,
     size bigint NOT NULL,
-    maker_fee bigint DEFAULT 0 NOT NULL,
-    taker_fee bigint DEFAULT 0 NOT NULL,
+    fee bigint DEFAULT 0 NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 

--- a/internal/platform/affiliate/pg_repository_test.go
+++ b/internal/platform/affiliate/pg_repository_test.go
@@ -56,9 +56,9 @@ func insertTestTrade(t *testing.T, pool *pgxpool.Pool, matchID string) string {
 	err = pool.QueryRow(ctx,
 		`INSERT INTO trades (
 			match_id, maker_order_id, taker_order_id, maker_address,
-			taker_address, market_id, price, size, maker_fee, taker_fee
+			taker_address, market_id, price, size, fee
 		) VALUES ($1, $2, $3, '0xmaker1', '0xmaker2',
-			'00000000-0000-0000-0000-000000000000', 50, 100, 5, 5)
+			'00000000-0000-0000-0000-000000000000', 50, 100, 5)
 		RETURNING id`, matchID, orderID1, orderID2,
 	).Scan(&tradeID)
 	if err != nil {

--- a/internal/trading/domain.go
+++ b/internal/trading/domain.go
@@ -147,8 +147,7 @@ type Trade struct {
 	MarketID     string    // Denormalized for query efficiency.
 	Price        int64     // Execution price in integer cents (1-99).
 	Size         int64     // Number of contracts traded.
-	MakerFee     int64     // Fee charged to maker, in cents.
-	TakerFee     int64     // Fee charged to taker, in cents.
+	Fee          int64     // Fee charged on the trade, from taker order's feeRateBps.
 	CreatedAt    time.Time // Set by database.
 }
 

--- a/internal/trading/pg_repository.go
+++ b/internal/trading/pg_repository.go
@@ -172,11 +172,11 @@ func (repo *PGRepository) SaveTrade(ctx context.Context, trade *Trade) error {
 	_, err = tx.Exec(ctx,
 		`INSERT INTO trades (
 			match_id, maker_order_id, taker_order_id, maker_address,
-			taker_address, market_id, price, size, maker_fee, taker_fee
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+			taker_address, market_id, price, size, fee
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
 		trade.MatchID, trade.MakerOrderID, trade.TakerOrderID,
 		trade.MakerAddress, trade.TakerAddress, trade.MarketID,
-		trade.Price, trade.Size, trade.MakerFee, trade.TakerFee,
+		trade.Price, trade.Size, trade.Fee,
 	)
 	if err != nil {
 		return fmt.Errorf("saving trade: inserting row: %w", err)

--- a/internal/trading/pg_repository_test.go
+++ b/internal/trading/pg_repository_test.go
@@ -283,8 +283,7 @@ func TestPGRepository_SaveTrade(t *testing.T) {
 		MarketID:     marketID,
 		Price:        50,
 		Size:         10,
-		MakerFee:     1,
-		TakerFee:     2,
+		Fee:          2,
 	}
 
 	if err := repo.SaveTrade(ctx, trade); err != nil {

--- a/migrations/trading/000002_create_trades.up.sql
+++ b/migrations/trading/000002_create_trades.up.sql
@@ -8,8 +8,7 @@ CREATE TABLE IF NOT EXISTS trades (
     market_id       UUID        NOT NULL,
     price           BIGINT      NOT NULL,
     size            BIGINT      NOT NULL,
-    maker_fee       BIGINT      NOT NULL DEFAULT 0,
-    taker_fee       BIGINT      NOT NULL DEFAULT 0,
+    fee             BIGINT      NOT NULL DEFAULT 0,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
 
     CONSTRAINT trades_match_id_unique UNIQUE (match_id)


### PR DESCRIPTION
## Summary
- Replaces `MakerFee int64` + `TakerFee int64` on `Trade` with a single `Fee int64` — maker fee is always 0, only takers are charged
- Updates migration `000002_create_trades.up.sql`, `pg_repository.go` INSERT (10 params → 9), `docs/schema.sql`, and both test files

## Test Plan
- [ ] `go build ./...` — passes
- [ ] `make lint` — passes
- [ ] `make test-integration` with stack running to verify `SaveTrade` and affiliate repo tests against the updated schema