### PR TITLE
Add Codex repository setup

### DIFF
--- a/.codex/agents/quick-task.md
+++ b/.codex/agents/quick-task.md
@@ -1,0 +1,106 @@
+---
+name: quick-task
+description: Execute a task independently: create a GitHub issue, get approval, implement, verify, and open a PR from an isolated worker context.
+---
+
+# Task Agent
+
+You execute tasks independently in the Shisa-Fosho/services repository. Assume you may be working alongside other agents or user edits. Do not revert edits made by others. If the harness gives you an isolated workspace, use it; if not, stop before mutating files and report that isolation is missing.
+
+## Before you start
+
+Read `CLAUDE.md` in the repo root for project conventions. Follow them exactly.
+
+## Workflow
+
+### 1. Understand the task
+
+Read the task description you've been given. If anything is unclear, ask for clarification before proceeding.
+
+### 2. Create a GitHub issue
+
+Create a well-scoped issue with clear acceptance criteria based on your understanding of the task:
+
+```bash
+gh issue create --repo Shisa-Fosho/services \
+  --title "<task title>" \
+  --body "<description with acceptance criteria>"
+```
+
+Capture the issue number.
+
+### 3. Add to project board
+
+```bash
+gh project item-add 2 --owner Shisa-Fosho --url https://github.com/Shisa-Fosho/services/issues/{number}
+```
+
+### 4. Present plan for approval
+
+Show the user:
+
+- Issue URL
+- What you plan to implement (bullet points)
+- Files you expect to touch
+- Estimated scope
+
+**Stop and wait for approval before implementing.** The user may have feedback or want to adjust the approach.
+
+### 5. Create a branch and implement
+
+```bash
+git checkout -b {issue_number}-{short-kebab-description}
+```
+
+- Follow conventions from `CLAUDE.md` and `docs/conventions.md`
+- Run `make lint && go build ./internal/...` after changes (if Go code)
+- Run relevant tests — `go test ./internal/...`
+
+### 6. Mandatory verification (BEFORE pushing)
+
+After implementing the work and BEFORE pushing or opening a PR:
+
+1. Run `git diff origin/main...HEAD --stat` to see the actual files changed
+2. Compare against the plan you proposed — every claimed file change must appear in the diff
+3. If any claimed change is MISSING from the diff (e.g. you said you deleted a file but `git status` shows it still exists), STOP and report the discrepancy — do not push
+
+If verification fails, your final message MUST say so explicitly. Do not summarize work as "done" if the diff doesn't match the plan.
+
+### 7. Commit, push, and open PR
+
+1. Stage relevant files (never stage secrets, binaries, or generated code)
+2. Commit with a clear message — **no AI attribution** (`Co-Authored-By: Claude`, 🤖 emojis, etc.)
+3. Push: `git push -u origin {branch_name}`
+4. Create PR:
+
+   ```bash
+   gh pr create --repo Shisa-Fosho/services \
+     --title "{issue title}" \
+     --body "Closes #{issue_number}
+
+   ## Summary
+   {bullet points of what changed}
+
+   ## Verified diff stat
+   \`\`\`
+   {paste of git diff --stat output}
+   \`\`\`
+
+   ## Test Plan
+   {how to verify}"
+   ```
+
+### 8. Post-push verification
+
+5. Run `gh pr diff <PR#> --repo Shisa-Fosho/services | head -200` to confirm GitHub shows the same diff you committed locally
+6. Run `gh pr view <PR#> --json baseRefOid,headRefOid` and confirm `baseRefOid` matches the current `origin/main` SHA
+
+### 9. Final report
+
+Return a message containing:
+
+- Issue URL
+- PR URL
+- Branch name
+- A copy of the `git diff --stat` output proving the changes are real
+- Verification result (all passed, or which step failed and why)

--- a/.codex/rules/conventions.md
+++ b/.codex/rules/conventions.md
@@ -1,0 +1,263 @@
+# Development Conventions
+
+> This is the authoritative style guide for the Shisa services monorepo. When in doubt, defer to this document.
+
+## General Principles
+
+1. **Clarity over cleverness** — readable code wins
+2. **Fail fast, validate early** — reject bad input at the boundary
+3. **Idempotency for all writes** — key source varies by operation; checked inside the same DB transaction as the write, never separately
+4. **Observable from day one** — structured logs + metrics + traces on every service
+5. **Test what matters** — domain logic thoroughly, integration paths with real dependencies
+
+## Go Style
+
+### Code Organization
+- Standard Go project layout
+- Internal packages for non-exported code
+- Domain logic in `internal/<service>/`
+- Shared infrastructure in `internal/shared/`
+
+### Naming
+- MixedCaps/camelCase (never underscores in Go identifiers)
+- Interface names: method name + "er" suffix for single-method interfaces (e.g., `Reader`, `Matcher`)
+- **All names (variables, parameters, receivers, struct fields, locals — anything that needs a name) must use full or, at worst, partial words that convey meaning.** Single-letter and 1-2 char abbreviations are prohibited. Examples:
+  - Receivers: `server` (not `s`), `repo` (not `r`), `engine` (not `e`), `handler` (not `h`), `book` (not `b`)
+  - Locals: `user` (not `u`), `order` (not `o`), `err` is allowed (idiomatic Go), `ctx` is allowed (idiomatic Go)
+  - Loop variables: `idx`/`index` (not `i`), `item` (not `v`) — even short loops should be readable
+  - The only exceptions are the universally idiomatic Go names: `ctx` (context.Context), `err` (error), `tx` (transaction), `ok` (bool from comma-ok idiom), `w`/`r` ONLY when they are `http.ResponseWriter` / `*http.Request` in a handler signature (standard library idiom)
+- Package names: short, lowercase, no underscores, no plural (e.g., `market`, `trading`, `settlement`)
+
+### Error Handling
+```go
+// Wrap with context using %w for unwrapping
+return fmt.Errorf("posting transaction %s: %w", txID, err)
+
+// Domain sentinel errors
+var (
+    ErrNotFound          = errors.New("not found")
+    ErrInsufficientFunds = errors.New("insufficient funds")
+    ErrMarketPaused      = errors.New("market is paused")
+    ErrOrderExpired      = errors.New("order expired")
+)
+
+// Rich error types when context matters
+type InsufficientFundsError struct {
+    UserAddress string
+    Required    int64
+    Available   int64
+}
+
+// Check with errors.Is/As — never string comparison
+if errors.Is(err, ErrNotFound) { ... }
+
+// Map domain errors to HTTP/gRPC status codes at the handler boundary
+```
+
+### Context
+- Always first parameter: `func DoThing(ctx context.Context, ...)`
+- Never store in structs
+- Use typed keys for context values (not strings)
+- Check `ctx.Err()` in loops and long operations
+- Propagate trace context through NATS messages
+
+```go
+type contextKey string
+const requestIDKey contextKey = "request_id"
+
+func WithRequestID(ctx context.Context, id string) context.Context {
+    return context.WithValue(ctx, requestIDKey, id)
+}
+```
+
+### Logging (Structured)
+```go
+logger.Info("order matched",
+    zap.String("request_id", reqID),
+    zap.String("order_id", orderID),
+    zap.String("market_id", marketID),
+    zap.String("user_address", addr),
+    zap.Int64("price", price),
+    zap.Int64("size", size),
+    zap.Duration("duration", elapsed),
+)
+```
+Standard fields: `request_id`, `user_address`, `order_id`, `market_id`, `tx_id`, `idempotency_key`, `duration`, `error`
+
+**Never log:** private keys, HMAC secrets, 2FA codes, full signatures, passwords, session tokens.
+
+### Testing
+- Table-driven with subtests: `t.Run(name, func(t *testing.T) { ... })`
+- `t.Parallel()` for independent unit tests; **avoid `t.Parallel()` in integration tests** that share a database — parallel truncation causes test pollution
+- Integration tests: `//go:build integration` (requires running stack)
+- Integration test runs across packages must use `-p 1` because packages share one physical database
+- Shared test helper: `postgres.TestPool(t)` from `internal/shared/postgres/testutil.go`
+- TDD: write tests first, `go build` to verify compilation, `go test` once implementation exists
+- Test naming: `TestFunctionName_Scenario` (e.g., `TestMatchOrders_InsufficientBalance`)
+- **Handler tests required** — every HTTP handler must have handler-level tests using `httptest.NewRecorder` + real mux routing. At minimum: one happy-path and one error-path test per endpoint. Auth-required endpoints must also test missing/invalid JWT.
+
+### Validation
+Domain validators (`ValidateUser`, `ValidateMarket`, `ValidatePosition`, etc.) are package-level functions in `internal/<domain>/validate.go` that return an error wrapping a domain sentinel (e.g., `ErrInvalidPosition`).
+
+**Where to call them:**
+- **Shape validators** — those that only inspect struct fields (`ValidateUser`, `ValidateMarket`, `ValidateEvent`, `ValidateReferral`, `ValidatePosition`, `ValidateEarning`) are called **inside the repository write method** (`CreateX`, `UpsertX`, `RecordX`). This gives "data reaching the DB is valid" as a property of the repository, so no caller can forget to validate.
+- **Business-rule validators** — those that need external context the repository doesn't have (`ValidateOrder` takes `MarketConfig` and `time.Time`) are called **by the caller** before invoking the repository. Repository doc comments state the contract.
+
+Validators remain exported so that future boundary layers (REST handlers, gRPC services, NATS consumers) can also invoke them for early input rejection and clean API error messages. Calling the same validator at both the boundary and inside the repository is fine — validation is cheap and double-checking is never wrong.
+
+**Rule of thumb**: if a validator only looks at the struct fields, the repo calls it. If it needs external context, the caller calls it.
+
+### Database (PostgreSQL)
+```go
+// Deferred rollback pattern (pgx)
+tx, err := pool.Begin(ctx)
+if err != nil { return fmt.Errorf("beginning transaction: %w", err) }
+defer tx.Rollback(ctx)
+
+// ... do work ...
+
+return tx.Commit(ctx)
+```
+- Use pgx driver (not database/sql)
+- Parameterized queries only (SQL injection prevention)
+- Idempotency checks inside the same transaction as writes
+- Deterministic lock ordering for concurrent access
+- JSONB for flexible config (market resolution params, etc.)
+- Migrations via golang-migrate
+
+### Migrations Are Append-Only After Merge
+
+**NEVER edit a migration that has been merged to `main`.** Once merged, a migration has been applied to every developer's dev DB and (eventually) every environment up to production. The migration tool tracks applied migrations by version number — it does NOT re-run a migration whose source has changed. So editing a merged migration creates **silent schema drift**: fresh DBs get the new shape, existing DBs stay on the old shape, and there is no migration that can bridge them.
+
+To change the schema after a migration has merged, **add a new migration** with the next version number that ALTERs forward from the current state. This is true even if the change feels "small" or "fixing a typo" — every migration is frozen the moment it lands on `main`.
+
+In production this drift is a disaster: you cannot drop and recreate the DB. The only recoveries are an emergency forward migration written under pressure, or a hand-written backfill script — both riskier and slower than doing it right the first time.
+
+#### Editing a Migration Before It Has Merged
+
+While a migration is on your branch and unmerged, you may iterate on it — but you MUST keep your local DB synced with the migration source. The required workflow:
+
+```bash
+make migrate-down   # roll back the migration you're about to edit
+# edit the .up.sql / .down.sql files
+make migrate-up     # re-apply the new version
+```
+
+Without the `migrate-down` step, the migration tool sees the old version as already applied and skips it on `migrate-up`, leaving your dev DB on the previous shape while the source says otherwise. This is the same drift pattern as editing-after-merge — it just happens locally first.
+
+If a `down` migration would drop test data you care about, copy it out before running down, then restore after up. Most "test data" is regeneratable from seed scripts; if it isn't, the seed scripts are the bug.
+
+#### Why This Matters For `docs/schema.sql`
+
+`docs/schema.sql` is generated by `pg_dump` against the local dev DB. The dump is canonical only if the dev DB matches the migration source. Down-before-edit is what keeps that invariant true. If anyone violates it, their dev DB drifts and any schema dump from that machine corrupts main's schema.sql.
+
+### NATS Messaging
+- Subject naming: `{domain}.{action}` (e.g., `trading.match`, `indexer.deposit.confirmed`)
+- JetStream streams for durable delivery (settlements, deposits, resolutions)
+- Core NATS for ephemeral fan-out (book updates, price ticks)
+- Always include trace context in message headers
+- Consumer names: `{service}-{action}` (e.g., `settlement-match-consumer`)
+
+### API Design
+- REST: standard HTTP status codes, JSON, idempotency keys for writes
+- gRPC: protobuf, appropriate status codes, server reflection enabled
+- All write endpoints require authentication
+- Public read endpoints (market data) are unauthenticated
+- Pagination: cursor-based for lists, not offset-based
+
+### Dependencies
+
+- **Before adding a new Go module**, always check `go.mod` and existing `internal/shared/` packages for libraries that already cover the need (including indirect dependencies that can be promoted to direct).
+- Prefer using existing dependencies over adding new ones. If an existing library provides the required primitives, implement on top of it rather than pulling in a wrapper package.
+- During planning, explicitly audit `go.mod` for overlap before proposing any `go get`.
+
+### Imports
+```go
+import (
+    // Standard library
+    "context"
+    "fmt"
+
+    // Third-party
+    "github.com/jackc/pgx/v5"
+    "go.uber.org/zap"
+
+    // Internal
+    "github.com/Shisa-Fosho/services/internal/trading"
+)
+```
+
+### Performance
+
+Default to the simplest correct implementation. Add complexity only on proven hot paths.
+
+| Call frequency | Examples | Rule |
+|----------------|----------|------|
+| Hot (high req/s) | Order matching, book fan-out | Optimize deliberately |
+| Warm | Trade history queries | Index + simple query |
+| Cold (rarely called) | Admin metadata updates, market creation | Simplest possible |
+
+**Before reaching for a complex implementation, ask:**
+- How often is this called? (Per-second vs. once a week?)
+- What does the naive approach actually cost at our scale?
+- Is this optimizing a real measured problem, or an imagined future one?
+
+**Antipattern:** A 50-line dynamic SQL builder that skips updating unchanged columns on a table that sees one write per month. A short, readable query that covers all cases is correct and fast enough permanently.
+
+### Idempotency
+
+All write operations MUST be idempotent. Key source depends on operation:
+- Orders: EIP-712 signature hash (cryptographic, natural key)
+- Deposits: Polygon tx hash (on-chain, natural key)
+- Settlements: Match ID from CLOB engine
+- Withdrawals: Client-supplied key + 2FA gate + server-side duplicate check
+- Affiliate claims: Server-generated from user + action
+
+Idempotency keys checked inside the same database transaction as the write — never in a separate system.
+
+### No Speculative Code
+
+Ship only code that is reached from real call sites within the current issue's scope. "Speculative" isn't limited to whole functions — the rule covers:
+
+- **Exported functions, methods, and option constructors** (`WithFoo`, `NewBar`). Go's unused-code detection only fires on *internal* identifiers — exported ones accumulate silently. You must check with grep, not trust the compiler.
+- **Parameters, struct fields, and interface methods** that no caller populates or reads. An unused `MiddlewareOption`, config field, or context key counts.
+- **Parallel-API symmetry** across packages. If package A has a `WithAuthFailureHook` and package B's version has no caller, don't mirror it into B "for consistency" — that's dead code dressed up as tidiness.
+- **Placeholder hooks, feature flags, and config fields** wired up "in case" a future issue needs them.
+
+If a future issue genuinely needs the missing piece, the build error (internal) or grep (exported) will surface it in seconds. Document expected prerequisites in the issue description — not in unreachable code.
+
+### On-chain Contract Bindings
+
+**Never hand-roll Solidity ABIs as Go string constants.** All contract interactions go through `abigen`-generated bindings produced from the canonical ABI JSON. The full pipeline:
+
+1. The ABI JSON lives under `internal/shared/eth/abi/<Contract>.json`, vendored from `shisa-contracts/abi/` (which exports them via `forge build`'s `extra_output_files`).
+2. `abigen` produces Go bindings under `internal/shared/eth/gen/<contract>/` from a `//go:generate` directive in `internal/shared/eth/generate.go`.
+3. The `gen/` directory is `.gitignore`d — generated code is regenerated on every fresh clone via `make build` (which depends on `make gen-contracts`).
+4. A thin reader wrapper in `internal/shared/eth/<contract>.go` exposes a narrow `*Reader` interface (e.g. `CTReader`, `NegRiskReader`) that hides the abigen verbosity and provides the surface handlers actually need.
+5. Service handlers declare *their own* local interface that is a subset of the shared reader, so the test fake stays minimal and the dependency surface is auditable per service.
+
+**Rules of thumb:**
+
+- One file per contract under `internal/shared/eth/` for the wrapper. Don't combine multiple contracts into one file — each is independently versioned.
+- The narrow reader interface ships in `internal/shared/eth/`. Per-service handler interfaces are local to that handler's package (not exported).
+- Handler tests fake the local interface, not the shared one. They never import the `gen/` packages.
+- Adding a new contract: drop the ABI JSON in `abi/`, add a `//go:generate` line in `generate.go`, write the wrapper, write the narrow interface. Run `make gen-contracts`.
+- Refreshing an ABI when upstream contracts change: rebuild `shisa-contracts` (`forge build`), copy the ABI JSON, run `make gen-contracts`. Never edit ABI JSON by hand.
+- `gen/` is regenerated by every developer's `make build`. Don't `git add` files under it.
+
+This pattern exists because hand-rolled ABI JSON literals and bind.Call dispatch invite typos that the compiler can't catch — wrong parameter names, wrong return types, mis-decoded `[32]byte` vs `common.Hash`. Catching those at codegen time instead of at runtime is a strict win.
+
+### Keeping CLAUDE.md In Sync
+
+Whenever you add, remove, or rename a directory as part of a task, ask the user
+whether they'd like to update the Code Organization section in `CLAUDE.md` to
+reflect the change. Don't update it silently — the user may have intentionally
+omitted a directory, or the change may be temporary.
+
+### Security
+- Never log sensitive data
+- Validate all inputs at service boundary
+- Parameterized queries only
+- TLS for all network communication
+- Set timeouts on all external calls (RPC, DB, blockchain)
+- EIP-712 signature verification for all order operations

--- a/.codex/rules/design-decisions.md
+++ b/.codex/rules/design-decisions.md
@@ -1,0 +1,36 @@
+# Design Decisions
+
+## Service Bootstrap Pattern
+
+Every service follows this structure in `cmd/<service>/main.go`:
+1. Create cancellable context
+2. Init observability (logger + metrics + tracer)
+3. Start metrics HTTP server (goroutine)
+4. Connect to PostgreSQL, NATS
+5. Set up signal handling (SIGINT/SIGTERM)
+6. Create and start gRPC server (with reflection + health checks)
+7. Block until shutdown signal or error
+8. Graceful shutdown (drain NATS, close DB, stop gRPC)
+
+## Communication Patterns
+
+| Type | Pattern | Use Case |
+|------|---------|----------|
+| External → us | REST (HTTP) | Client orders, market queries, user data |
+| External → us | WebSocket | Real-time book, prices, fills |
+| Service → service (sync) | gRPC | Trading ↔ Platform queries |
+| Service → service (async) | NATS JetStream | Matches → settlement, deposits → balance |
+| Fan-out (ephemeral) | NATS Core | Book updates → WebSocket, price changes |
+
+## Key Design Decisions
+
+1. **Unified order book** — BUY YES @ $0.40 = SELL NO @ $0.60, doubles liquidity
+2. **Off-chain matching, on-chain settlement** — instant UX, blockchain trustlessness
+3. **Universal proxy wallets** — Gnosis Safe (wallet users), Poly Proxy (email users)
+4. **Instant confirmation** — off-chain ledger updated on match, settlement in background
+5. **NATS for all async** — JetStream (durable) + Core (ephemeral)
+6. **PostgreSQL JSONB** — flexible market config, resolution parameters
+7. **Split auth by service** — Platform service owns **session-auth endpoints** (`/auth/nonce`, `/auth/signup/*`, `/auth/login/*`, `/auth/refresh`, `/auth/logout`, `/auth/session`). Trading service owns the **Polymarket-compatible API-key lifecycle** (`/auth/derive-api-key`, `/auth/api-keys`, `/auth/api-key`). JWT verification lives in `internal/platform/auth` and is platform-only; HMAC/API-key verification lives in `internal/trading/auth` and is trading-only. This split matches Polymarket's own architectural division (gamma-api vs clob).
+8. **Two non-overlapping auth middlewares** — `Authenticate` (JWT-only) for platform-owned session endpoints; `AuthenticateAPIKey` (HMAC-only, via `APIKeyReader`) for Polymarket-compat CLOB endpoints. **No endpoint accepts both.** A valid JWT on a CLOB-protected route gets 401 — enforced by a dedicated test. Rationale: keeps the auth contract unambiguous for SDK consumers and prevents the security surface from doubling on trading routes.
+9. **No reverse proxy — direct service ports** — Services are reached directly: trading on :8080, platform on :8081. There is no longer a single unified entry point. Note: the Polymarket clob-client SDK assumed all endpoints (both session-auth and CLOB) were served from one host; with nginx removed, SDK clients must target each service port separately. Endpoint migration to consolidate this is a separate task.
+10. **Naming convention** — `internal/shared/` is cross-service infrastructure. Service-specific domain code lives under the service's own path (`internal/platform/auth/`, `internal/platform/market/`, `internal/platform/affiliate/`, `internal/trading/auth/`, etc.). Top-level `internal/` entries are either **services** (`platform/`, `trading/`, `settlement/`, `indexer/`) or **cross-service infrastructure** (`shared/`) — no other category.

--- a/.codex/rules/polymarket.md
+++ b/.codex/rules/polymarket.md
@@ -1,0 +1,86 @@
+# Polymarket Compatibility
+
+Our REST API aims for compatibility with Polymarket's CLOB client SDKs. The
+upstream SDK source is the **authoritative spec** — not general knowledge,
+not prior implementations, not pattern-matching from similar systems.
+
+## Pinned Reference Versions
+
+| Repo | Pinned ref | Purpose |
+|------|-----------|---------|
+| `Polymarket/clob-client` | `v5.8.2` | TypeScript SDK — auth headers, request signing, REST client |
+| `Polymarket/py-clob-client` | `v0.34.6` | Python SDK — cross-reference for TS |
+| `Polymarket/clob-order-utils` | `main` | Order signing primitives (pin when stable) |
+| `Polymarket/ctf-exchange` | `80cbf37` | Core CTFExchange contract — `Order` EIP-712 struct, fee enforcement, settlement |
+| `Polymarket/neg-risk-ctf-adapter` | `v2.0.0` | Multi-outcome (NegRisk) settlement adapter |
+| `Polymarket/exchange-fee-module` | `v2.0.0` | `FeeModule` + `NegRiskFeeModule` — admin-operated fee refund / withdrawal |
+| `Polymarket/conditional-tokens-contracts` | `v1.0.3` | Conditional token minting, splitting, merging, redemption |
+| `Polymarket/proxy-factories` | `master` | Poly Proxy / Gnosis Safe user-wallet factories (pin when stable) |
+
+Bump these versions intentionally when you decide to upgrade compatibility
+target. Do not drift — if planning work references a newer behavior, pin
+higher first.
+
+## SDK Verification Rule
+
+Before planning or implementing any Polymarket-compatible surface (auth
+headers, order signing, REST endpoints, response formats):
+
+1. **Fetch the source from the pinned tag.** Use `gh api` so the fetch is
+   reproducible and tied to a specific commit:
+   ```bash
+   # List directory:
+   gh api repos/Polymarket/clob-client/contents/src/headers?ref=v5.8.2 --jq '.[].name'
+
+   # Read a file:
+   gh api repos/Polymarket/clob-client/contents/src/headers/index.ts?ref=v5.8.2 \
+     --jq '.content' | base64 -d
+   ```
+2. **Extract the exact contract** — header names, field names, types, ordering,
+   signing payload format — and document it in the plan.
+3. **Derive tests from SDK behavior, not from the implementation.** Writing
+   both code and tests from your own mental model creates a closed loop
+   where the tests validate the wrong assumption. Tests must assert what
+   a real SDK client sends and expects, including the **absence** of fields
+   the SDK doesn't use.
+4. **Cross-reference both SDKs** when one is ambiguous. If `clob-client` (TS)
+   and `py-clob-client` (Python) disagree, flag it to the user rather than
+   picking one silently.
+
+## Why This Matters (Incident Log)
+
+- **PR #48 (nonce tracker)**: first implementation added an in-memory nonce
+  tracker keyed on a `POLY_NONCE` header for HMAC-signed requests. The actual
+  clob-client L2 headers don't send `POLY_NONCE` — it's only used on L1
+  (EIP-712) headers. Caught in review by fetching the SDK source; the entire
+  nonce subsystem was removed. Rule exists to prevent recurrence.
+
+## Contracts (Read-Only Reference)
+
+ABIs consumed from the `contracts` repo via copy. No import dependency.
+Contract source is pinned — see the pinned versions table above for authoritative
+repo refs. Fetch via `gh api repos/Polymarket/<repo>/contents/<path>?ref=<pin>`.
+
+- CTFExchange (`Polymarket/ctf-exchange`) — binary market settlement, per-order fee in EIP-712 payload
+- NegRiskCTFAdapter (`Polymarket/neg-risk-ctf-adapter`) — multi-outcome market settlement
+- ConditionalTokens (`Polymarket/conditional-tokens-contracts`) — token minting, splitting, merging, redemption
+- Fee Module (`Polymarket/exchange-fee-module`) — admin-operated fee refund / withdrawal (rates live per-order, not here)
+- Proxy Factories (`Polymarket/proxy-factories`) — user wallet deployment
+
+## Fee Model (Confirmed Against Pinned Contracts)
+
+- **Fees are per-order, not global.** The `Order` EIP-712 struct in
+  `Polymarket/ctf-exchange` (`src/exchange/libraries/OrderStructs.sol`)
+  includes a `feeRateBps` field; users consent to the rate by signing it.
+- **Hard on-chain cap is `MAX_FEE_RATE_BIPS = 1000` (10%)**, a `pure`
+  constant in `src/exchange/mixins/Fees.sol`. Not admin-settable —
+  changing it requires a contract upgrade. Backend validators must not
+  allow signing orders above this, or the exchange will revert.
+- **Polymarket's REST API exposes `GET /fee-rate?token_id=X`** returning
+  a `base_fee` per market (see `clob-client/src/client.ts`
+  `getFeeRateBps(tokenID)`). Rates are per-token, not a single global value.
+- **No maker/taker split at the protocol level.** Each order carries a
+  single `feeRateBps`. Operator policy decides what rate to stamp onto
+  maker vs taker orders as they are built.
+- **FeeModule is not a rate source** — it's an admin-operated refund /
+  withdrawal utility that sits next to the exchange.

--- a/.codex/skills/align-planning/SKILL.md
+++ b/.codex/skills/align-planning/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: align-planning
+description: Cross-check and align all planning sources — GitHub issues, GitHub project board, Notion Build Order doc, and Notion Technical Plan. Finds and fixes drift between them.
+---
+
+# Align Planning
+
+Audits all planning sources for consistency and fixes any drift. Run this after any change to the backlog — new issues, reordering, scope changes, architectural decisions, or issue updates.
+
+**Invoke when:**
+
+- After creating or updating GitHub issues
+- After changing the project board (build order, phase, status)
+- After making architectural changes that affect service responsibilities
+- After any conversation where we decide to move, rename, or rescope work
+- As the final step of the `/create-issue` skill
+- Whenever the user says "align", "sync planning", "check alignment", or similar
+
+## Sources of Truth
+
+| Source                    | What it contains                                                       | ID / Location                               |
+| ------------------------- | ---------------------------------------------------------------------- | ------------------------------------------- |
+| **GitHub Issues**         | Issue titles, descriptions, scope, dependencies, labels, state         | `gh issue list --repo Shisa-Fosho/services` |
+| **GitHub Project Board**  | Build Order numbers, Phase assignments, Status                         | Project #2, org Shisa-Fosho                 |
+| **Notion Build Order**    | Issue Key table, Blocking Dependencies table, dependency graphs        | `33092032f61981b6b762de2bab90eaf8`          |
+| **Notion Technical Plan** | Architecture, service responsibilities, component ownership, MVP scope | `32b92032f619811aa868f4d75f5017c8`          |
+
+## Step 1: Gather Current State (in parallel)
+
+### 1a. GitHub Issues
+
+```bash
+gh issue list --repo Shisa-Fosho/services --state all --limit 100 --json number,title,state,labels,body
+```
+
+### 1b. GitHub Project Board
+
+```
+gh api graphql -f query='{ organization(login: "Shisa-Fosho") { projectV2(number: 2) { items(first: 50) { nodes { bo: fieldValueByName(name: "Build Order") { ... on ProjectV2ItemFieldNumberValue { number } } phase: fieldValueByName(name: "Phase") { ... on ProjectV2ItemFieldSingleSelectValue { name } } status: fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } } content { ... on Issue { title number } ... on DraftIssue { title } } } } } } }'
+```
+
+### 1c. Notion Build Order doc
+
+```
+notion-fetch: 33092032f61981b6b762de2bab90eaf8
+```
+
+### 1d. Notion Technical Plan
+
+```
+notion-fetch: 32b92032f619811aa868f4d75f5017c8
+```
+
+## Step 2: Cross-Check for Drift
+
+Run each check and collect findings. Do NOT fix anything yet — gather all findings first.
+
+### 2a. Title Consistency
+
+For each item in the Notion Issue Key table, check that the corresponding GitHub issue title matches. Flag mismatches.
+
+### 2b. Build Order Consistency
+
+Compare the ordering in the Notion Issue Key table against the GitHub project board Build Order numbers. Flag items that appear in a different sequence.
+
+### 2c. Phase Consistency
+
+Compare the Phase column in Notion vs the Phase field on the GitHub project board. Flag mismatches.
+
+### 2d. Dependency Consistency
+
+For each item in the Notion Blocking Dependencies table:
+
+1. Check that every "blocked-by" reference is bidirectional — if A is blocked by B, then B's "blocks" column should list A.
+2. Check that blocked-by items have a lower or equal build order number on the project board.
+3. Check that blocks items have a higher build order number.
+4. Check that the GitHub issue body's Dependencies section matches the Notion dependencies table.
+5. Flag any circular dependencies.
+
+### 2e. Scope / Architecture Consistency
+
+Check the Notion Technical Plan's service responsibility assignments against what the code actually does:
+
+- Which service owns which endpoints (check nginx.conf routing + cmd/\*/main.go wiring)
+- Which components are listed under which service in the Tech Plan
+- Flag any component listed in the wrong service
+
+### 2f. Coverage Check
+
+1. Every item in the Notion Build Order should have a corresponding GitHub issue.
+2. Every GitHub issue with a build-order ID (S1, T3a, P2.1, SEC1, etc.) should appear in the Notion Build Order.
+3. MVP scope items in the Technical Plan should be tracked by at least one GitHub issue.
+4. Flag any items on the project board that are missing from Notion, or vice versa.
+
+### 2g. Status Consistency
+
+- GitHub issues marked as CLOSED should have status "Done" on the project board.
+- Items with status "In Progress" on the board should have an open GitHub issue.
+
+## Step 3: Present Findings For Approval and Iterate With User if Needed
+
+Present all findings in a table:
+
+```
+## Alignment Audit
+
+| # | Category | Source A | Source B | Issue | Severity |
+|---|----------|---------|---------|-------|----------|
+| 1 | Title    | GitHub #31 "P2.1: Admin Wallet..." | Notion "P2.1: HTTP Utilities..." | Title mismatch | Medium |
+| 2 | Phase    | GitHub Board: Phase 3 | Notion: Phase 2 | SEC1 phase drift | Medium |
+| ... | | | | | |
+
+**No issues found:** ✓ (if everything is aligned)
+```
+
+Severity levels:
+
+- **High:** Contradictory information that could cause wrong work (e.g., component in wrong service)
+- **Medium:** Stale data that could confuse (e.g., title mismatch, dependency mismatch)
+- **Low:** Minor cosmetic drift (e.g., slightly different wording)
+
+If there are no findings, confirm alignment is clean and skip to Step 5.
+
+## Step 4: Once User approves Fix Drift
+
+For each finding, fix it in the source that's stale. The priority order for "which source is correct" is:
+
+1. **Code / nginx.conf** — what the system actually does is always right
+2. **GitHub Issues** — the most recently updated description wins
+3. **GitHub Project Board** — build order and phase numbers
+4. **Notion docs** — updated to match the above
+
+Apply fixes:
+
+### Notion Build Order updates
+
+```
+notion-update-page: 33092032f61981b6b762de2bab90eaf8
+```
+
+### Notion Technical Plan updates
+
+```
+notion-update-page: 32b92032f619811aa868f4d75f5017c8
+```
+
+### GitHub Project Board updates
+
+```bash
+# Phase
+gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id <item_id> --field-id PVTSSF_lADOEC3v5M4BUX8izhBgiKE --single-select-option-id <phase_option_id>
+
+# Build Order
+gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id <item_id> --field-id PVTF_lADOEC3v5M4BUX8izhBgiK8 --number <build_order>
+
+# Status
+gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id <item_id> --field-id PVTSSF_lADOEC3v5M4BUX8izhBgiFs --single-select-option-id <status_option_id>
+```
+
+### GitHub Issue updates (if needed)
+
+```bash
+gh issue edit <number> --repo Shisa-Fosho/services --title "<title>" --body "<body>"
+```
+
+**Phase option IDs:**
+
+- `ff13e535` — Phase 0: Foundation
+- `a9afd19d` — Phase 1: Domain Types
+- `5e1a5684` — Phase 2: First Flow
+- `52a6971d` — Phase 3: Frontend + APIs
+- `bd9808b9` — Phase 4: On-Chain Workers
+- `9be4cd6d` — Phase 5: Bot
+- `ebeb2cff` — Phase 6: Pre-Launch
+
+**Status option IDs:**
+
+- `f75ad846` — Todo
+- `47fc9ee4` — In Progress
+- `98236657` — Done
+
+**Project field IDs:**
+
+- Project: `PVT_kwDOEC3v5M4BUX8i`
+- Status: `PVTSSF_lADOEC3v5M4BUX8izhBgiFs`
+- Phase: `PVTSSF_lADOEC3v5M4BUX8izhBgiKE`
+- Build Order: `PVTF_lADOEC3v5M4BUX8izhBgiK8`
+
+## Step 5: Report
+
+```
+## Alignment Report
+
+**Sources checked:** GitHub Issues, Project Board, Notion Build Order, Notion Technical Plan
+**Findings:** <N> issues found, <M> fixed
+
+### Fixes Applied
+- <what changed, where>
+
+### Still Aligned
+- ✓ Titles match across GitHub and Notion
+- ✓ Build order consistent between project board and Notion
+- ✓ Phases consistent
+- ✓ Dependencies bidirectional and order-consistent
+- ✓ Service ownership matches code + nginx routing
+- ✓ All MVP scope items tracked
+- ✓ Statuses consistent
+```

--- a/.codex/skills/begin-task/SKILL.md
+++ b/.codex/skills/begin-task/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: begin-task
+description: Start working on a GitHub issue in Shisa-Fosho/services. Use when the user asks to begin an issue, start issue work, or work on a numbered GitHub issue; reads the issue, checks blockers, creates a safe branch, updates planning state, and plans before implementation.
+---
+
+# Begin Task
+
+1. Read the GitHub issue: `gh issue view {issue_number} --repo Shisa-Fosho/services`
+2. **Check for blocking dependencies** before proceeding:
+   - Parse the issue body for "blocked-by" or "blocked by" references to other issues (e.g., `#4`, `#7`)
+   - For each blocker, run `gh issue view {blocker_number} --repo Shisa-Fosho/services --json state,title,number` to check if it's still open
+   - If ANY blockers are still **open**, warn the developer clearly:
+     ```
+     ⚠ BLOCKERS DETECTED — this issue has open dependencies:
+       • #{number} "{title}" (state: OPEN)
+     ```
+   - Ask the developer whether to proceed anyway (they may have a stub/workaround strategy) or switch to working on a blocker first. Do NOT silently continue.
+   - If all blockers are closed, note this and proceed normally.
+3. Parse the issue title to derive a branch name: `{issue_number}-{short-kebab-description}`
+4. Ensure working tree is clean: `git status --porcelain`
+5. Create the branch via the **`create-branch`** skill, which guarantees the branch is based on a freshly fetched `origin/main` rather than the current HEAD. Never run ad-hoc `git checkout -b` here.
+6. Move the issue to "In Progress" on the project board and assign it:
+   - `gh issue edit {issue_number} --repo Shisa-Fosho/services --add-assignee @me`
+   - Move to In Progress: `gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id {item_id} --field-id PVTSSF_lADOEC3v5M4BUX8izhBgiFs --single-select-option-id 47fc9ee4`
+   - To get the item ID, run: `gh project item-list 2 --owner Shisa-Fosho --format json --limit 50 | node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8')); const i=d.items.find(x=>x.title.includes('{issue_title_fragment}')); if(i) console.log(i.id); else console.error('item not found');"`
+7. Discuss the approach before writing code. In Codex Default mode, do not implement until the user confirms the plan when this skill is invoked specifically to begin a tracked issue.
+8. Check if the issue has a parent and if so read the parent and any sibling issues so that you can gain full context around how the issue fits into the greater epic.
+9. **Size check (during planning):** After exploring the codebase and designing the implementation, estimate the total hand-written LOC (excluding generated code and tests). The target is **≤ 800 LOC of production code per PR**.
+   - If the estimate exceeds 800 LOC, do NOT proceed with a single large implementation. Instead:
+     ```
+     ⚠ SIZE LIMIT — estimated ~{N} LOC exceeds the 800 LOC target.
+     Proposed split into sub-issues:
+       1. "{sub-issue title}" (~{LOC} LOC) — {one-line scope}
+       2. "{sub-issue title}" (~{LOC} LOC) — {one-line scope}
+       ...
+     ```
+   - Present the split plan to the developer for approval. Each sub-issue should be independently mergeable and testable.
+   - On approval, create the sub-issues via `gh issue create` with the parent issue referenced, then proceed with the first sub-issue only.
+   - If the developer prefers to keep it as one PR, proceed but note the exception.
+
+Branch naming examples:
+- Issue #12 "CLOB matching engine" → `12-clob-matching-engine`
+- Issue #5 "PostgreSQL schema" → `5-postgresql-schema`

--- a/.codex/skills/commit-push-pr/SKILL.md
+++ b/.codex/skills/commit-push-pr/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: commit-push-pr
+description: Stage relevant changes, commit, push, and open or update a GitHub PR for Shisa-Fosho/services. Use when the user asks to commit, push, open a PR, or finish a branch with a PR.
+---
+
+# Commit, Push & PR
+
+1. Stage relevant files (never stage secrets, binaries, or generated code)
+2. Generate commit message from diff if not provided
+3. Commit (no AI attribution in commit messages)
+4. Push with `-u origin {branch}` if no upstream set
+5. **Before creating the PR, re-read AGENTS.md and CLAUDE.md** to check for any rules about commit messages, PR bodies, or attribution. AGENTS.md is the Codex entry point; CLAUDE.md remains a project source document.
+6. Create PR if none exists, update if one does:
+   - Title from branch/commit
+   - Body with ## Summary, ## Test Plan
+   - Add appropriate labels
+   - **No AI attribution anywhere** — no "Generated with Claude", no "Co-Authored-By: Claude", nothing
+7. Return the PR URL
+
+## Schema Dump
+
+If any `migrations/**/*.sql` files are in the staged changes, regenerate `docs/schema.sql` before committing:
+
+1. Ensure the local stack is running (`make up` if needed)
+2. Run migrations: `DATABASE_URL="postgres://shisa:shisa@localhost:5432/shisa?sslmode=disable" go run ./cmd/migrate up`
+3. Dump the schema: `docker exec deploy-postgres-1 pg_dump --schema-only --no-owner --no-privileges -U shisa shisa 2>/dev/null | grep -v '\\restrict' | grep -v '\\unrestrict' > docs/schema.sql`
+4. Stage `docs/schema.sql` alongside the migration files
+
+**Never commit:**
+- `.env` files or secrets
+- `proto/gen/` (generated code)
+- Binary files
+- Node modules or vendor directories

--- a/.codex/skills/create-branch/SKILL.md
+++ b/.codex/skills/create-branch/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: create-branch
+description: Create a new git branch safely — always from a freshly fetched origin/main, never from the currently checked-out branch. Use whenever a new branch is needed (starting an issue, spinning off a skill/config tweak, hotfix, etc.).
+---
+
+# Create Branch
+
+Always branch from **remote `origin/main`** — never from whatever branch is currently checked out.
+
+## Why this exists
+
+Branching from the current branch inherits its commits. If that branch holds pre-squash commits of an already-merged PR (common when the PR was squash-merged on GitHub), the new branch will include those commits as "new" work, polluting any PR opened from it. The fix is to always base off `origin/main` directly.
+
+## Steps
+
+1. **Check working tree is clean:**
+   ```bash
+   git status --porcelain
+   ```
+   If there are uncommitted changes, STOP and surface them to the user. Do not silently stash or discard — the user must decide (stash, commit to a dedicated branch, or abandon).
+
+2. **Fetch latest from remote:**
+   ```bash
+   git fetch origin
+   ```
+
+3. **Create the branch directly from `origin/main`:**
+   ```bash
+   git checkout -b {branch_name} origin/main
+   ```
+   This form bypasses the local `main` branch entirely. Never use `git checkout main && git pull && git checkout -b ...` — that path fails silently if you're on an unrelated branch, if local `main` has drifted, or if a squash-merge left old commits reachable from your current HEAD.
+
+4. **Verify the branch is where you expect:**
+   ```bash
+   git log --oneline origin/main..HEAD
+   ```
+   Expect **zero commits** output. If anything appears, the branch was not created from a clean base — stop and investigate before committing anything.
+
+## Anti-patterns (do NOT do these)
+
+- `git checkout -b <name>` (no explicit base) — branches from current HEAD, the exact bug this skill prevents.
+- `git checkout main && git pull && git checkout -b <name>` — assumes local `main` tracks `origin/main` correctly and that you're able to switch to it cleanly. Fails when the working tree is dirty or local `main` has diverged.
+- Branching without fetching first — you may base off stale refs.

--- a/.codex/skills/create-issue/SKILL.md
+++ b/.codex/skills/create-issue/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: create-issue
+description: Create a new backlog issue with full planning-doc alignment for Shisa-Fosho/services. Use when the user asks to create an issue, add backlog work, scope new work, place work in build order, or sync GitHub issues, project board, and Notion planning docs.
+---
+
+# Create Issue
+
+Structured workflow for adding new items to the backlog. Ensures alignment across GitHub issues, the GitHub project board, and Notion planning docs.
+
+**Invoke when:** We decide to create a new issue during a conversation, or the user says "create an issue for X."
+
+## Step 1: Assess Current State
+
+Gather context from three sources **in parallel**:
+
+### 1a. Fetch the current GitHub backlog
+```bash
+gh issue list --repo Shisa-Fosho/services --state all --limit 100 --json number,title,state,labels
+```
+
+### 1b. Fetch the Notion Build Order doc
+```
+notion-fetch: 33092032f61981b6b762de2bab90eaf8
+```
+Extract the Issue Key table and Blocking Dependencies table.
+
+### 1c. Fetch the Notion Technical & Product Plan
+```
+notion-fetch: 32b92032f619811aa868f4d75f5017c8
+```
+Scan for sections relevant to the proposed issue — look for requirements, scope, or design decisions that should inform the issue description.
+
+### 1d. Review the active conversation
+Read back through the current chat to capture any decisions, context, or constraints discussed that should be reflected in the issue.
+
+## Step 2: Duplicate & Overlap Check
+
+Before proposing the issue:
+
+1. **Search existing issues** for keyword overlap with the proposed work:
+   ```bash
+   gh issue list --repo Shisa-Fosho/services --state all --search "<keywords>" --json number,title,state
+   ```
+2. **Check the Notion Technical Plan** for whether this work is already scoped under an existing item.
+3. If overlap is found, **tell the user** and ask whether to:
+   - Extend the existing issue instead
+   - Create a new issue that references the existing one
+   - Proceed with a new standalone issue
+
+## Step 3: Propose Issue Contents
+
+Present a draft to the user with:
+
+```
+## Proposed Issue
+
+**Title:** <concise title, prefixed with build-order ID if applicable>
+**Labels:** <inferred from component — use existing label set>
+
+**Body:**
+## Parent Context
+<link to parent issue or Notion section>
+
+## Description
+<what and why>
+
+## Scope
+<bullet list of deliverables>
+
+## Estimated LoC
+<rough estimate if applicable>
+
+## Acceptance Criteria
+- [ ] <testable criteria>
+
+## Dependencies
+- **blocked-by:** <issue refs>
+- **blocks:** <issue refs>
+```
+
+**Label inference rules:**
+- `internal/shared/` → `component:shared-platform`
+- `internal/trading/` or `cmd/trading/` → `component:trading-service`
+- `internal/market/` or `internal/data/` or `cmd/platform/` → `component:platform-service`
+- New feature → `type:feature`
+- Bug fix → `type:bug`
+- Cleanup/refactor → `type:chore`
+
+**Ask the user:**
+- Confirm the issue contents
+- Any adjustments to scope, dependencies, or labels
+- Clarify anything ambiguous from the conversation
+
+Do NOT proceed until the user confirms.
+
+## Step 4: Propose Build Order Placement
+
+Fetch the current build order from the GitHub project board:
+```
+gh api graphql -f query='{ organization(login: "Shisa-Fosho") { projectV2(number: 2) { items(first: 50) { nodes { bo: fieldValueByName(name: "Build Order") { ... on ProjectV2ItemFieldNumberValue { number } } phase: fieldValueByName(name: "Phase") { ... on ProjectV2ItemFieldSingleSelectValue { name } } content { ... on Issue { title number } ... on DraftIssue { title } } } } } } }'
+```
+
+Present the current order and propose where the new issue slots in:
+
+```
+Current build order around the insertion point:
+  BO=N   | Phase X | <item before>
+  BO=N+1 | Phase X | ← NEW: <proposed issue title>
+  BO=N+2 | Phase X | <item after>
+
+Phase: <proposed phase>
+Rationale: <why it goes here — what it depends on and what depends on it>
+```
+
+**Rules for placement:**
+- If it's a subtask of an existing parent, use parent.N numbering (e.g., 8.5)
+- If inserting between existing items, renumber downstream items to maintain integer ordering
+- Check that blocked-by items have a lower build order number
+- Check that blocks items have a higher build order number
+
+**Dependency validation (run before presenting to user):**
+1. For each `blocked-by` reference: verify the referenced issue exists, is in a lower or equal build order position, and is in the same or earlier phase. Flag violations.
+2. For each `blocks` reference: verify the referenced issue exists and is in a higher build order position. Flag violations.
+3. Check for **circular dependencies** — if A blocks B and B blocks A (directly or transitively), flag it.
+4. If any violations are found, present them alongside the proposal with a suggested fix (e.g., "this should be in Phase 2 instead of Phase 3 because it's blocked by a Phase 2 item").
+
+**Build order gap detection:**
+1. After determining the insertion point, scan for numbering gaps or collisions in the current build order.
+2. If the insertion creates a collision (e.g., two items at BO=16), renumber downstream items before presenting.
+3. If there's already a gap at the right position (e.g., nothing between BO=15 and BO=17), use the gap rather than renumbering.
+
+**Ask the user** to confirm placement. Do NOT proceed until confirmed.
+
+## Step 5: Create & Update Everything
+
+Once the user confirms both the issue contents and placement, execute all updates:
+
+### 5a. Create the GitHub issue
+```bash
+gh issue create --repo Shisa-Fosho/services --title "<title>" --label "<labels>" --body "<body>"
+```
+
+### 5b. Add to GitHub project board and set fields
+```bash
+# Add to project
+gh project item-add 2 --owner Shisa-Fosho --url <issue_url>
+
+# Get the item ID
+gh project item-list 2 --owner Shisa-Fosho --format json --limit 50
+
+# Set Phase
+gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id <item_id> --field-id PVTSSF_lADOEC3v5M4BUX8izhBgiKE --single-select-option-id <phase_option_id>
+
+# Set Build Order
+gh project item-edit --project-id PVT_kwDOEC3v5M4BUX8i --id <item_id> --field-id PVTF_lADOEC3v5M4BUX8izhBgiK8 --number <build_order>
+```
+
+**Phase option IDs:**
+- `ff13e535` — Phase 0: Foundation
+- `a9afd19d` — Phase 1: Domain Types
+- `5e1a5684` — Phase 2: First Flow
+- `52a6971d` — Phase 3: Frontend + APIs
+- `bd9808b9` — Phase 4: On-Chain Workers
+- `9be4cd6d` — Phase 5: Bot
+- `ebeb2cff` — Phase 6: Pre-Launch
+
+**Project field IDs:**
+- Project: `PVT_kwDOEC3v5M4BUX8i`
+- Status: `PVTSSF_lADOEC3v5M4BUX8izhBgiFs` (options: `f75ad846`=Todo, `47fc9ee4`=In Progress, `98236657`=Done)
+- Phase: `PVTSSF_lADOEC3v5M4BUX8izhBgiKE`
+- Build Order: `PVTF_lADOEC3v5M4BUX8izhBgiK8`
+
+### 5c. Renumber downstream items if needed
+If the insertion required renumbering (not using .N subtask notation), update all affected items' Build Order numbers.
+
+### 5d. Run `/align-planning`
+Invoke the `align-planning` skill to sync the new issue into Notion docs and verify full cross-source consistency. This handles:
+- Adding the item to the Notion Build Order Issue Key table and Blocking Dependencies table
+- Updating the Notion Technical Plan if the issue maps to a specific section
+- Verifying all dependencies are bidirectional and order-consistent
+- Catching any drift introduced by the new issue
+
+## Step 6: Report
+
+Provide a concise summary of what was created:
+
+```
+## Issue Created
+- **#<number>:** <title>
+- **Phase:** <phase>
+- **Build Order:** <number>
+- **Labels:** <labels>
+- **Blocked by:** <refs>
+- **Blocks:** <refs>
+```
+
+The alignment report from `/align-planning` covers Notion updates and consistency verification.

--- a/.codex/skills/quick-task/SKILL.md
+++ b/.codex/skills/quick-task/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: quick-task
+description: Dispatch a task to a Codex worker subagent in the background using an isolated worktree-style workflow. Use only when the user explicitly asks for quick-task, delegation, a background agent, or parallel agent work.
+---
+
+# Quick Task Launcher
+
+Dispatch the task to a Codex `worker` subagent only when the user explicitly asks for delegation or background agent work.
+
+Use `spawn_agent` with `agent_type: "worker"` and a prompt based on `.codex/agents/quick-task.md`. Tell the worker it is not alone in the codebase, must not revert edits made by others, and must list changed paths in its final response.
+
+## After dispatching
+
+Tell the user: "Dispatched to a worker agent in the background. Continue working; I will integrate or report its result when needed."
+
+Do nothing else. Do not implement the task yourself. Do not poll the agent — wait for the completion notification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# AGENTS.md - Shisa Services Codex Setup
+
+This is the Codex entry point for the Shisa-Fosho services repository. The
+Claude setup is preserved in `.claude/`; do not replace, remove, or rewrite it
+when updating Codex configuration. Codex-specific mirrors live under `.codex/`.
+
+## Project Overview
+
+Prediction market platform backend services, shared packages, protobuf
+definitions, migrations, and infrastructure configs. The system is a Polymarket
+style fork: off-chain CLOB matching, on-chain Polygon settlement, and USDC
+collateral.
+
+Primary services:
+
+| Service | Responsibility | HTTP | gRPC | Metrics |
+| --- | --- | --- | --- | --- |
+| Trading | CLOB engine, REST API, WebSocket, Polymarket-compatible API-key lifecycle | 8080 | 9001 | 9091 |
+| Platform | Session auth, market API, data API, admin API, affiliate | 8081 | 9002 | 9092 |
+| Settlement Worker | On-chain trade settlement, relayer | - | 9003 | 9093 |
+| Indexer | On-chain event monitoring, deposits | - | 9004 | 9094 |
+
+Resolution worker automation is deferred; manual resolution is handled through
+admin wallet flows plus backend verification.
+
+## Essential Commands
+
+```bash
+make up               # Start local stack
+make down             # Stop and clean up
+make build            # Compile all services
+make test             # Run unit tests
+make test-integration # Integration tests; requires stack
+make lint             # golangci-lint + go vet
+make proto            # Generate protobuf code
+make fmt              # gofmt + goimports
+make migrate-up       # Run migrations
+make migrate-down     # Roll back last migration
+make tools            # Install dev tools
+```
+
+## Code Organization
+
+- `cmd/`: service entry points.
+- `internal/shared/`: cross-service infrastructure used by all services.
+- `internal/platform/`: platform service domains such as auth, market, data,
+  admin, and affiliate.
+- `internal/trading/`: trading service domain, CLOB data, and API-key auth.
+- `internal/settlement/`, `internal/indexer/`, `internal/resolution/`: worker
+  domains.
+- `proto/`: protobuf definitions and Buf config.
+- `migrations/`: SQL migrations, ordered `shared` then `platform` then
+  `trading`.
+- `deploy/`: Docker Compose and observability infrastructure.
+- `docs/`: architecture, conventions, schema, and planning docs.
+
+When adding, removing, or renaming directories, ask the user whether to update
+the Code Organization section in `CLAUDE.md` and this file. Do not silently
+rewrite those sections.
+
+## Codex Mirrors
+
+Full project rules ported from Claude live here:
+
+- `.codex/rules/conventions.md`: authoritative development conventions.
+- `.codex/rules/design-decisions.md`: service bootstrap, communication
+  patterns, and architectural decisions.
+- `.codex/rules/polymarket.md`: pinned Polymarket compatibility references and
+  verification rules.
+- `.codex/skills/`: Codex skill mirrors of the Claude workflows.
+- `.codex/agents/quick-task.md`: Codex-adapted quick-task worker instructions.
+
+Read the relevant `.codex/rules/*.md` before making substantive changes. The
+root `CLAUDE.md` remains a source document for project context and should be
+kept in sync when the user explicitly approves.
+
+## Development Rules
+
+- Favor clarity over cleverness and simple correct implementations over
+  speculative abstractions.
+- Validate inputs at service boundaries and inside repository write methods
+  where validators only inspect struct shape.
+- All writes must be idempotent, with idempotency checks inside the same
+  database transaction as the write.
+- Use structured logs, metrics, and tracing. Never log private keys, HMAC
+  secrets, passwords, session tokens, full signatures, or similar sensitive
+  values.
+- Use pgx and parameterized SQL only.
+- Migrations are append-only after merge. If a migration is already merged to
+  `main`, add a new migration instead of editing it.
+- If editing an unmerged migration, run `make migrate-down`, edit, then
+  `make migrate-up` so the local DB matches the source.
+- Never hand-roll Solidity ABIs as Go string constants. Use vendored ABI JSON
+  plus abigen-generated bindings and narrow wrapper interfaces.
+- Do not add speculative exported functions, options, config fields, hooks, or
+  mirrored APIs with no real caller. Check exported usage with search.
+- Before adding a Go dependency, inspect `go.mod` and `internal/shared/` for an
+  existing suitable library.
+
+## Go Style
+
+- Use meaningful names. Avoid single-letter variables except idiomatic `ctx`,
+  `err`, `tx`, `ok`, and `w`/`r` for HTTP handler signatures.
+- Keep context as the first parameter, never stored in structs.
+- Wrap errors with `%w`; use `errors.Is` and `errors.As`, never string
+  comparisons.
+- Domain errors should be mapped to HTTP or gRPC statuses at the handler
+  boundary.
+- Handler tests are required for HTTP handlers: at least happy path and error
+  path, plus missing/invalid JWT for auth-required endpoints.
+- Integration tests use `//go:build integration`; avoid `t.Parallel()` when a
+  shared DB is involved. Cross-package integration runs need `-p 1`.
+
+## Git And PR Rules
+
+- Branch format: `{issue#}-{short-description}`.
+- Create new branches from freshly fetched `origin/main`, not the current HEAD.
+- Do not add AI attribution to commits or PRs.
+- Never commit generated code under `proto/gen/`, secrets, `.env` files,
+  binaries, `node_modules`, or vendor directories.
+- If `migrations/**/*.sql` changes, regenerate and stage `docs/schema.sql`
+  before committing.
+- Before pushing a task branch, compare `git diff origin/main...HEAD --stat`
+  against the promised plan and report any mismatch.
+
+## Polymarket Compatibility
+
+For Polymarket-compatible behavior, upstream SDK and contract sources at pinned
+versions are the spec. Fetch and inspect the pinned source before implementing
+auth headers, order signing, endpoint shapes, response formats, fee behavior, or
+contract interactions. Derive tests from SDK behavior, not from the local
+implementation.
+
+Pinned details and incident notes are in `.codex/rules/polymarket.md`.


### PR DESCRIPTION
## Summary
- Add AGENTS.md as the Codex entry point for repo guidance
- Mirror Claude rules into .codex/rules without modifying .claude
- Add Codex-compatible skill and quick-task agent mirrors under .codex

## Test Plan
- Ran frontmatter check across .codex/skills/*/SKILL.md
- Skill validator previously passed before moving files into the isolated worktree; rerun in worktree was blocked by local Python missing PyYAML

## Verified diff stat
```text
.codex/agents/quick-task.md           | 106 ++++++++++++++
.codex/rules/conventions.md           | 263 ++++++++++++++++++++++++++++++++++
.codex/rules/design-decisions.md      |  36 +++++
.codex/rules/polymarket.md            |  86 +++++++++++
.codex/skills/align-planning/SKILL.md | 208 +++++++++++++++++++++++++++
.codex/skills/begin-task/SKILL.md     |  43 ++++++
.codex/skills/commit-push-pr/SKILL.md |  33 +++++
.codex/skills/create-branch/SKILL.md  |  43 ++++++
.codex/skills/create-issue/SKILL.md   | 197 +++++++++++++++++++++++++
.codex/skills/quick-task/SKILL.md     |  16 +++
AGENTS.md                             | 134 +++++++++++++++++
11 files changed, 1165 insertions(+)
```