### PR TITLE
test: assert error response reasons

### DIFF
--- a/internal/platform/auth/handler_test.go
+++ b/internal/platform/auth/handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Shisa-Fosho/services/internal/platform/data"
 	"github.com/Shisa-Fosho/services/internal/shared/eth"
+	"github.com/Shisa-Fosho/services/internal/shared/testassert"
 )
 
 // fakeVerifier implements auth.MessageVerifier for handler tests.
@@ -121,13 +122,6 @@ func testHandler(t *testing.T, repo *fakeRepo, verifier *fakeVerifier) *Handler 
 	return NewHandler(zaptest.NewLogger(t), repo, jwtMgr, verifier, safeCfg, false)
 }
 
-func assertBodyContains(t *testing.T, recorder *httptest.ResponseRecorder, want string) {
-	t.Helper()
-	if !strings.Contains(recorder.Body.String(), want) {
-		t.Errorf("body = %q, want substring %q", recorder.Body.String(), want)
-	}
-}
-
 func TestSignupWallet_Success(t *testing.T) {
 	t.Parallel()
 
@@ -190,7 +184,7 @@ func TestSignupWallet_DuplicateUser(t *testing.T) {
 	if recorder.Code != http.StatusConflict {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusConflict)
 	}
-	assertBodyContains(t, recorder, "user already exists")
+	testassert.BodyContains(t, recorder, "user already exists")
 }
 
 func TestSignupWallet_MissingUsername(t *testing.T) {
@@ -209,7 +203,7 @@ func TestSignupWallet_MissingUsername(t *testing.T) {
 	if recorder.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
-	assertBodyContains(t, recorder, "message, signature, and username are required")
+	testassert.BodyContains(t, recorder, "message, signature, and username are required")
 }
 
 func TestLoginWallet_Success(t *testing.T) {
@@ -252,7 +246,7 @@ func TestLoginWallet_UnknownUser(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
-	assertBodyContains(t, recorder, "user not found")
+	testassert.BodyContains(t, recorder, "user not found")
 }
 
 func TestRefresh_Success(t *testing.T) {
@@ -313,7 +307,7 @@ func TestRefresh_RevokedToken(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
-	assertBodyContains(t, recorder, "token revoked")
+	testassert.BodyContains(t, recorder, "token revoked")
 }
 
 func TestRefresh_MissingCookie(t *testing.T) {
@@ -331,7 +325,7 @@ func TestRefresh_MissingCookie(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
-	assertBodyContains(t, recorder, "missing refresh token")
+	testassert.BodyContains(t, recorder, "missing refresh token")
 }
 
 func TestLogout_ClearsCookie(t *testing.T) {
@@ -410,7 +404,7 @@ func TestSession_InvalidToken(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
-	assertBodyContains(t, recorder, "invalid token")
+	testassert.BodyContains(t, recorder, "invalid token")
 }
 
 func TestNonce_ReturnsNonce(t *testing.T) {

--- a/internal/platform/auth/handler_test.go
+++ b/internal/platform/auth/handler_test.go
@@ -121,6 +121,13 @@ func testHandler(t *testing.T, repo *fakeRepo, verifier *fakeVerifier) *Handler 
 	return NewHandler(zaptest.NewLogger(t), repo, jwtMgr, verifier, safeCfg, false)
 }
 
+func assertBodyContains(t *testing.T, recorder *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	if !strings.Contains(recorder.Body.String(), want) {
+		t.Errorf("body = %q, want substring %q", recorder.Body.String(), want)
+	}
+}
+
 func TestSignupWallet_Success(t *testing.T) {
 	t.Parallel()
 
@@ -183,6 +190,7 @@ func TestSignupWallet_DuplicateUser(t *testing.T) {
 	if recorder.Code != http.StatusConflict {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusConflict)
 	}
+	assertBodyContains(t, recorder, "user already exists")
 }
 
 func TestSignupWallet_MissingUsername(t *testing.T) {
@@ -201,6 +209,7 @@ func TestSignupWallet_MissingUsername(t *testing.T) {
 	if recorder.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
+	assertBodyContains(t, recorder, "message, signature, and username are required")
 }
 
 func TestLoginWallet_Success(t *testing.T) {
@@ -243,6 +252,7 @@ func TestLoginWallet_UnknownUser(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
+	assertBodyContains(t, recorder, "user not found")
 }
 
 func TestRefresh_Success(t *testing.T) {
@@ -303,6 +313,7 @@ func TestRefresh_RevokedToken(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
+	assertBodyContains(t, recorder, "token revoked")
 }
 
 func TestRefresh_MissingCookie(t *testing.T) {
@@ -320,6 +331,7 @@ func TestRefresh_MissingCookie(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
+	assertBodyContains(t, recorder, "missing refresh token")
 }
 
 func TestLogout_ClearsCookie(t *testing.T) {
@@ -398,6 +410,7 @@ func TestSession_InvalidToken(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
+	assertBodyContains(t, recorder, "invalid token")
 }
 
 func TestNonce_ReturnsNonce(t *testing.T) {

--- a/internal/platform/auth/middleware_test.go
+++ b/internal/platform/auth/middleware_test.go
@@ -65,6 +65,7 @@ func TestAuthenticate_MissingHeader(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
+	assertBodyContains(t, recorder, "missing authorization header")
 }
 
 func TestAuthenticate_MalformedHeader(t *testing.T) {
@@ -84,6 +85,7 @@ func TestAuthenticate_MalformedHeader(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
+	assertBodyContains(t, recorder, "invalid authorization header")
 }
 
 func TestAuthenticate_ExpiredToken(t *testing.T) {
@@ -191,6 +193,7 @@ func TestRequireAdmin_NonAdminGets403(t *testing.T) {
 	if recorder.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusForbidden)
 	}
+	assertBodyContains(t, recorder, "forbidden")
 	if *called {
 		t.Error("downstream handler should not be called for non-admin")
 	}
@@ -212,6 +215,7 @@ func TestRequireAdmin_MissingUserContextGets403(t *testing.T) {
 	if recorder.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusForbidden)
 	}
+	assertBodyContains(t, recorder, "forbidden")
 	if *called {
 		t.Error("downstream handler should not be called without user context")
 	}
@@ -233,6 +237,7 @@ func TestRequireAdmin_RepoErrorGets500(t *testing.T) {
 	if recorder.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
 	}
+	assertBodyContains(t, recorder, "internal error")
 	if *called {
 		t.Error("downstream handler should not be called on repo error")
 	}

--- a/internal/platform/auth/middleware_test.go
+++ b/internal/platform/auth/middleware_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/Shisa-Fosho/services/internal/shared/testassert"
 )
 
 // fakeAdminRepo is a tiny in-memory data.AdminRepository for middleware tests.
@@ -65,7 +67,7 @@ func TestAuthenticate_MissingHeader(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
-	assertBodyContains(t, recorder, "missing authorization header")
+	testassert.BodyContains(t, recorder, "missing authorization header")
 }
 
 func TestAuthenticate_MalformedHeader(t *testing.T) {
@@ -85,7 +87,7 @@ func TestAuthenticate_MalformedHeader(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
-	assertBodyContains(t, recorder, "invalid authorization header")
+	testassert.BodyContains(t, recorder, "invalid authorization header")
 }
 
 func TestAuthenticate_ExpiredToken(t *testing.T) {
@@ -193,7 +195,7 @@ func TestRequireAdmin_NonAdminGets403(t *testing.T) {
 	if recorder.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusForbidden)
 	}
-	assertBodyContains(t, recorder, "forbidden")
+	testassert.BodyContains(t, recorder, "forbidden")
 	if *called {
 		t.Error("downstream handler should not be called for non-admin")
 	}
@@ -215,7 +217,7 @@ func TestRequireAdmin_MissingUserContextGets403(t *testing.T) {
 	if recorder.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusForbidden)
 	}
-	assertBodyContains(t, recorder, "forbidden")
+	testassert.BodyContains(t, recorder, "forbidden")
 	if *called {
 		t.Error("downstream handler should not be called without user context")
 	}
@@ -237,7 +239,7 @@ func TestRequireAdmin_RepoErrorGets500(t *testing.T) {
 	if recorder.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
 	}
-	assertBodyContains(t, recorder, "internal error")
+	testassert.BodyContains(t, recorder, "internal error")
 	if *called {
 		t.Error("downstream handler should not be called on repo error")
 	}

--- a/internal/platform/market/handler_onchain_test.go
+++ b/internal/platform/market/handler_onchain_test.go
@@ -444,4 +444,6 @@ func TestOnchain_ChainReadFailure_Returns502(test *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		test.Errorf("status = %d body=%q, want 502", rec.Code, rec.Body.String())
 	}
+	// Chain-read failures intentionally share one generic 502 body; the isolated
+	// codeless ConditionalTokens setup above pins this rejection to slot-count read.
 }

--- a/internal/platform/market/handler_test.go
+++ b/internal/platform/market/handler_test.go
@@ -721,6 +721,13 @@ func doRequest(t *testing.T, h http.Handler, method, target string, body []byte)
 	return rec
 }
 
+func assertBodyContains(t *testing.T, rec *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	if !strings.Contains(rec.Body.String(), want) {
+		t.Errorf("body = %q, want substring %q", rec.Body.String(), want)
+	}
+}
+
 func registeredMux(t *testing.T, repo Repository) *http.ServeMux {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -765,6 +772,7 @@ func TestHandler_CreateCategory_DuplicateSlug(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", rec.Code)
 	}
+	assertBodyContains(t, rec, "slug already in use")
 }
 
 func TestHandler_CreateCategory_MissingFields(t *testing.T) {
@@ -783,6 +791,7 @@ func TestHandler_CreateCategory_MissingFields(t *testing.T) {
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("name=%q slug=%q: status = %d, want 400", tc.name, tc.slug, rec.Code)
 		}
+		assertBodyContains(t, rec, "name and slug are required")
 	}
 }
 
@@ -795,6 +804,7 @@ func TestHandler_CreateCategory_MalformedJSON(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
+	assertBodyContains(t, rec, "invalid JSON")
 }
 
 func TestHandler_CreateCategory_RepoError(t *testing.T) {
@@ -809,6 +819,7 @@ func TestHandler_CreateCategory_RepoError(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", rec.Code)
 	}
+	assertBodyContains(t, rec, "internal server error")
 }
 
 func TestHandler_UpdateCategory_Success(t *testing.T) {
@@ -846,6 +857,7 @@ func TestHandler_UpdateCategory_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "category not found")
 }
 
 func TestHandler_UpdateCategory_DuplicateSlug(t *testing.T) {
@@ -863,6 +875,7 @@ func TestHandler_UpdateCategory_DuplicateSlug(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", rec.Code)
 	}
+	assertBodyContains(t, rec, "slug already in use")
 }
 
 func TestHandler_DeleteCategory_Success(t *testing.T) {
@@ -890,6 +903,7 @@ func TestHandler_DeleteCategory_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "category not found")
 }
 
 func TestHandler_UpdateEvent_Success(t *testing.T) {
@@ -960,6 +974,7 @@ func TestHandler_UpdateEvent_EmptyCategoryRejected(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400 (category cannot be cleared)", rec.Code)
 	}
+	assertBodyContains(t, rec, "category_id cannot be empty")
 }
 
 func TestHandler_UpdateEvent_NotFound(t *testing.T) {
@@ -972,6 +987,7 @@ func TestHandler_UpdateEvent_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "event not found")
 }
 
 func TestHandler_UpdateEvent_EmptyBody(t *testing.T) {
@@ -985,6 +1001,7 @@ func TestHandler_UpdateEvent_EmptyBody(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400 for empty update", rec.Code)
 	}
+	assertBodyContains(t, rec, "no fields to update")
 }
 
 func TestHandler_UpdateMarket_Success(t *testing.T) {
@@ -1025,6 +1042,7 @@ func TestHandler_UpdateMarket_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "not found")
 }
 
 func TestHandler_PauseMarket_Success(t *testing.T) {
@@ -1075,6 +1093,7 @@ func TestHandler_PauseMarket_InvalidTransition(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", rec.Code)
 	}
+	assertBodyContains(t, rec, "invalid status transition")
 }
 
 func TestHandler_PauseMarket_NotFound(t *testing.T) {
@@ -1085,6 +1104,7 @@ func TestHandler_PauseMarket_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "not found")
 }
 
 func TestHandler_SetFeeRate_Success(t *testing.T) {
@@ -1128,6 +1148,7 @@ func TestHandler_SetFeeRate_OutOfRange(t *testing.T) {
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("bps=%d: status = %d, want 400", tc.FeeRateBps, rec.Code)
 		}
+		assertBodyContains(t, rec, "fee_rate_bps")
 	}
 }
 
@@ -1140,6 +1161,7 @@ func TestHandler_SetFeeRate_MarketNotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "not found")
 }
 
 func TestHandler_SetFeeRate_MalformedJSON(t *testing.T) {
@@ -1152,6 +1174,7 @@ func TestHandler_SetFeeRate_MalformedJSON(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
+	assertBodyContains(t, rec, "invalid JSON")
 }
 
 func TestHandler_SetFeeRate_RepoError(t *testing.T) {
@@ -1165,6 +1188,7 @@ func TestHandler_SetFeeRate_RepoError(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", rec.Code)
 	}
+	assertBodyContains(t, rec, "internal server error")
 }
 
 // muxWithPublisher mirrors registeredMux but lets the caller substitute a
@@ -1246,6 +1270,7 @@ func TestHandler_BulkPauseMarkets_EmptyList(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
+	assertBodyContains(t, rec, "market_ids is required")
 }
 
 func TestHandler_BulkPauseMarkets_OneNotFound_FailsAllOrNothing(t *testing.T) {
@@ -1260,6 +1285,7 @@ func TestHandler_BulkPauseMarkets_OneNotFound_FailsAllOrNothing(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "not found")
 	// All-or-nothing: m1 must NOT have been paused.
 	if repo.markets[m1.ID].Status != StatusActive {
 		t.Errorf("m1 status = %s, want ACTIVE (batch must roll back)", repo.markets[m1.ID].Status)
@@ -1304,6 +1330,7 @@ func TestHandler_BulkPauseMarkets_OneResolved_FailsAllOrNothing(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", rec.Code)
 	}
+	assertBodyContains(t, rec, "invalid status transition")
 	if repo.markets[m1.ID].Status != StatusActive {
 		t.Errorf("m1 status = %s, want ACTIVE (resolved m2 must not partially commit)",
 			repo.markets[m1.ID].Status)
@@ -1325,6 +1352,7 @@ func TestHandler_BulkPauseMarkets_KVPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("status = %d, want 502", rec.Code)
 	}
+	assertBodyContains(t, rec, "config publish failed")
 	// DB write committed before publish — m1 is paused even though publish failed.
 	if repo.markets[m1.ID].Status != StatusPaused {
 		t.Errorf("m1 status = %s, want PAUSED — DB commit must succeed before KV publish",
@@ -1343,6 +1371,7 @@ func TestHandler_PauseMarket_KVPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", rec.Code)
 	}
+	assertBodyContains(t, rec, "config publish failed")
 	// DB write must still have committed — the market must be paused.
 	if repo.markets[seed.ID].Status != StatusPaused {
 		t.Errorf("market.Status = %s, want PAUSED — DB commit must succeed before KV publish",
@@ -1367,6 +1396,7 @@ func TestHandler_PauseMarket_StatusPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", rec.Code)
 	}
+	assertBodyContains(t, rec, "status-change broadcast failed")
 	// KV publish ran and succeeded — the failure was the second-stage broadcast.
 	if len(pub.configCalls) != 1 {
 		t.Errorf("PublishMarketConfig called %d times, want 1", len(pub.configCalls))
@@ -1425,6 +1455,7 @@ func TestHandler_GetMarket_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "not found")
 }
 
 func TestHandler_UpdateMarket_KVPublishFailureReturns502(t *testing.T) {
@@ -1444,6 +1475,7 @@ func TestHandler_UpdateMarket_KVPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", rec.Code)
 	}
+	assertBodyContains(t, rec, "config publish failed")
 }
 
 func TestHandler_SetFeeRate_PublishesConfig(t *testing.T) {
@@ -1475,6 +1507,7 @@ func TestHandler_SetFeeRate_KVPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", rec.Code)
 	}
+	assertBodyContains(t, rec, "config publish failed")
 }
 
 func TestHandler_MethodNotAllowed(t *testing.T) {
@@ -1487,6 +1520,7 @@ func TestHandler_MethodNotAllowed(t *testing.T) {
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status = %d, want 405", rec.Code)
 	}
+	// The stdlib mux owns 405 responses, so there is no handler-specific failure reason to assert.
 }
 
 // --- helpers for new endpoint tests --------------------------------------
@@ -1616,6 +1650,7 @@ func TestHandler_CreateEvent_Binary_MissingQuestionID(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
+	assertBodyContains(t, rec, "question_id is required")
 }
 
 func TestHandler_CreateEvent_Binary_EmptyMarkets(t *testing.T) {
@@ -1636,6 +1671,7 @@ func TestHandler_CreateEvent_Binary_EmptyMarkets(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
+	assertBodyContains(t, rec, "markets is required")
 }
 
 func TestHandler_CreateEvent_Binary_OnChainNotPrepared(t *testing.T) {
@@ -1820,6 +1856,7 @@ func TestHandler_CreateEvent_Binary_TokenIDChainError(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("status = %d body=%q, want 502", rec.Code, rec.Body.String())
 	}
+	assertBodyContains(t, rec, "chain read failed")
 }
 
 // --- /admin/events POST (NEG_RISK) --------------------------------------
@@ -1926,6 +1963,7 @@ func TestHandler_CreateEvent_NegRisk_MissingMarketID(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
+	assertBodyContains(t, rec, "neg_risk_market_id is required")
 }
 
 func TestHandler_CreateEvent_NegRisk_SingleMarket(t *testing.T) {
@@ -1949,6 +1987,7 @@ func TestHandler_CreateEvent_NegRisk_SingleMarket(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
+	assertBodyContains(t, rec, "at least 2 markets")
 }
 
 // --- /admin/events/{id}/resolve -----------------------------------------
@@ -2097,6 +2136,7 @@ func TestHandler_ResolveEvent_EventNotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "event not found")
 }
 
 func TestHandler_ResolveEvent_NegRiskFriendlyError(t *testing.T) {
@@ -2331,6 +2371,7 @@ func TestHandler_SetTradingConfig_InvalidTickSize(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
+	assertBodyContains(t, rec, "invalid tick_size")
 }
 
 func TestHandler_SetTradingConfig_NotFound(t *testing.T) {
@@ -2342,6 +2383,7 @@ func TestHandler_SetTradingConfig_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
+	assertBodyContains(t, rec, "not found")
 }
 
 func TestHandler_SetTradingConfig_PublishFailure(t *testing.T) {
@@ -2356,6 +2398,7 @@ func TestHandler_SetTradingConfig_PublishFailure(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("status = %d, want 502", rec.Code)
 	}
+	assertBodyContains(t, rec, "config publish failed")
 }
 
 // --- live-status overlay on GET /admin/markets/{id} ----------------------
@@ -2417,6 +2460,7 @@ func TestHandler_GetMarket_BucketReadFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("status = %d, want 502", rec.Code)
 	}
+	assertBodyContains(t, rec, "reading live market config failed")
 }
 
 // --- idempotent retry after a failed publish ------------------------------
@@ -2450,6 +2494,7 @@ func TestHandler_ResolveEvent_RetrySameOutcomeRepublishes(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("first resolve status = %d, want 502", rec.Code)
 	}
+	assertBodyContains(t, rec, "config publish failed")
 	if repo.markets[marketID].Status != StatusResolved {
 		t.Fatalf("market status = %s, want RESOLVED (DB committed before publish)",
 			repo.markets[marketID].Status)
@@ -2506,6 +2551,7 @@ func TestHandler_ResolveEvent_RetryDifferentOutcomeConflicts(t *testing.T) {
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Errorf("conflicting retry status = %d, want 422", rec.Code)
 	}
+	assertBodyContains(t, rec, "on-chain numerators")
 }
 
 func TestHandler_VoidEvent_RetryRepublishes(t *testing.T) {
@@ -2536,6 +2582,7 @@ func TestHandler_VoidEvent_RetryRepublishes(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("first void status = %d, want 502", rec.Code)
 	}
+	assertBodyContains(t, rec, "config publish failed")
 
 	pub.configErr = nil
 	pub.configCalls = nil

--- a/internal/platform/market/handler_test.go
+++ b/internal/platform/market/handler_test.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
+
+	"github.com/Shisa-Fosho/services/internal/shared/testassert"
 )
 
 // fakeRepo is an in-memory Repository double for handler tests. The methods
@@ -721,13 +723,6 @@ func doRequest(t *testing.T, h http.Handler, method, target string, body []byte)
 	return rec
 }
 
-func assertBodyContains(t *testing.T, rec *httptest.ResponseRecorder, want string) {
-	t.Helper()
-	if !strings.Contains(rec.Body.String(), want) {
-		t.Errorf("body = %q, want substring %q", rec.Body.String(), want)
-	}
-}
-
 func registeredMux(t *testing.T, repo Repository) *http.ServeMux {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -772,7 +767,7 @@ func TestHandler_CreateCategory_DuplicateSlug(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", rec.Code)
 	}
-	assertBodyContains(t, rec, "slug already in use")
+	testassert.BodyContains(t, rec, "slug already in use")
 }
 
 func TestHandler_CreateCategory_MissingFields(t *testing.T) {
@@ -791,7 +786,7 @@ func TestHandler_CreateCategory_MissingFields(t *testing.T) {
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("name=%q slug=%q: status = %d, want 400", tc.name, tc.slug, rec.Code)
 		}
-		assertBodyContains(t, rec, "name and slug are required")
+		testassert.BodyContains(t, rec, "name and slug are required")
 	}
 }
 
@@ -804,7 +799,7 @@ func TestHandler_CreateCategory_MalformedJSON(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
-	assertBodyContains(t, rec, "invalid JSON")
+	testassert.BodyContains(t, rec, "invalid JSON")
 }
 
 func TestHandler_CreateCategory_RepoError(t *testing.T) {
@@ -819,7 +814,7 @@ func TestHandler_CreateCategory_RepoError(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", rec.Code)
 	}
-	assertBodyContains(t, rec, "internal server error")
+	testassert.BodyContains(t, rec, "internal server error")
 }
 
 func TestHandler_UpdateCategory_Success(t *testing.T) {
@@ -857,7 +852,7 @@ func TestHandler_UpdateCategory_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "category not found")
+	testassert.BodyContains(t, rec, "category not found")
 }
 
 func TestHandler_UpdateCategory_DuplicateSlug(t *testing.T) {
@@ -875,7 +870,7 @@ func TestHandler_UpdateCategory_DuplicateSlug(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", rec.Code)
 	}
-	assertBodyContains(t, rec, "slug already in use")
+	testassert.BodyContains(t, rec, "slug already in use")
 }
 
 func TestHandler_DeleteCategory_Success(t *testing.T) {
@@ -903,7 +898,7 @@ func TestHandler_DeleteCategory_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "category not found")
+	testassert.BodyContains(t, rec, "category not found")
 }
 
 func TestHandler_UpdateEvent_Success(t *testing.T) {
@@ -974,7 +969,7 @@ func TestHandler_UpdateEvent_EmptyCategoryRejected(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400 (category cannot be cleared)", rec.Code)
 	}
-	assertBodyContains(t, rec, "category_id cannot be empty")
+	testassert.BodyContains(t, rec, "category_id cannot be empty")
 }
 
 func TestHandler_UpdateEvent_NotFound(t *testing.T) {
@@ -987,7 +982,7 @@ func TestHandler_UpdateEvent_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "event not found")
+	testassert.BodyContains(t, rec, "event not found")
 }
 
 func TestHandler_UpdateEvent_EmptyBody(t *testing.T) {
@@ -1001,7 +996,7 @@ func TestHandler_UpdateEvent_EmptyBody(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400 for empty update", rec.Code)
 	}
-	assertBodyContains(t, rec, "no fields to update")
+	testassert.BodyContains(t, rec, "no fields to update")
 }
 
 func TestHandler_UpdateMarket_Success(t *testing.T) {
@@ -1042,7 +1037,7 @@ func TestHandler_UpdateMarket_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "not found")
+	testassert.BodyContains(t, rec, "not found")
 }
 
 func TestHandler_PauseMarket_Success(t *testing.T) {
@@ -1093,7 +1088,7 @@ func TestHandler_PauseMarket_InvalidTransition(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", rec.Code)
 	}
-	assertBodyContains(t, rec, "invalid status transition")
+	testassert.BodyContains(t, rec, "invalid status transition")
 }
 
 func TestHandler_PauseMarket_NotFound(t *testing.T) {
@@ -1104,7 +1099,7 @@ func TestHandler_PauseMarket_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "not found")
+	testassert.BodyContains(t, rec, "not found")
 }
 
 func TestHandler_SetFeeRate_Success(t *testing.T) {
@@ -1148,7 +1143,7 @@ func TestHandler_SetFeeRate_OutOfRange(t *testing.T) {
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("bps=%d: status = %d, want 400", tc.FeeRateBps, rec.Code)
 		}
-		assertBodyContains(t, rec, "fee_rate_bps")
+		testassert.BodyContains(t, rec, "fee_rate_bps")
 	}
 }
 
@@ -1161,7 +1156,7 @@ func TestHandler_SetFeeRate_MarketNotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "not found")
+	testassert.BodyContains(t, rec, "not found")
 }
 
 func TestHandler_SetFeeRate_MalformedJSON(t *testing.T) {
@@ -1174,7 +1169,7 @@ func TestHandler_SetFeeRate_MalformedJSON(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
-	assertBodyContains(t, rec, "invalid JSON")
+	testassert.BodyContains(t, rec, "invalid JSON")
 }
 
 func TestHandler_SetFeeRate_RepoError(t *testing.T) {
@@ -1188,7 +1183,7 @@ func TestHandler_SetFeeRate_RepoError(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", rec.Code)
 	}
-	assertBodyContains(t, rec, "internal server error")
+	testassert.BodyContains(t, rec, "internal server error")
 }
 
 // muxWithPublisher mirrors registeredMux but lets the caller substitute a
@@ -1270,7 +1265,7 @@ func TestHandler_BulkPauseMarkets_EmptyList(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
-	assertBodyContains(t, rec, "market_ids is required")
+	testassert.BodyContains(t, rec, "market_ids is required")
 }
 
 func TestHandler_BulkPauseMarkets_OneNotFound_FailsAllOrNothing(t *testing.T) {
@@ -1285,7 +1280,7 @@ func TestHandler_BulkPauseMarkets_OneNotFound_FailsAllOrNothing(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "not found")
+	testassert.BodyContains(t, rec, "not found")
 	// All-or-nothing: m1 must NOT have been paused.
 	if repo.markets[m1.ID].Status != StatusActive {
 		t.Errorf("m1 status = %s, want ACTIVE (batch must roll back)", repo.markets[m1.ID].Status)
@@ -1330,7 +1325,7 @@ func TestHandler_BulkPauseMarkets_OneResolved_FailsAllOrNothing(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", rec.Code)
 	}
-	assertBodyContains(t, rec, "invalid status transition")
+	testassert.BodyContains(t, rec, "invalid status transition")
 	if repo.markets[m1.ID].Status != StatusActive {
 		t.Errorf("m1 status = %s, want ACTIVE (resolved m2 must not partially commit)",
 			repo.markets[m1.ID].Status)
@@ -1352,7 +1347,7 @@ func TestHandler_BulkPauseMarkets_KVPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("status = %d, want 502", rec.Code)
 	}
-	assertBodyContains(t, rec, "config publish failed")
+	testassert.BodyContains(t, rec, "config publish failed")
 	// DB write committed before publish — m1 is paused even though publish failed.
 	if repo.markets[m1.ID].Status != StatusPaused {
 		t.Errorf("m1 status = %s, want PAUSED — DB commit must succeed before KV publish",
@@ -1371,7 +1366,7 @@ func TestHandler_PauseMarket_KVPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", rec.Code)
 	}
-	assertBodyContains(t, rec, "config publish failed")
+	testassert.BodyContains(t, rec, "config publish failed")
 	// DB write must still have committed — the market must be paused.
 	if repo.markets[seed.ID].Status != StatusPaused {
 		t.Errorf("market.Status = %s, want PAUSED — DB commit must succeed before KV publish",
@@ -1396,7 +1391,7 @@ func TestHandler_PauseMarket_StatusPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", rec.Code)
 	}
-	assertBodyContains(t, rec, "status-change broadcast failed")
+	testassert.BodyContains(t, rec, "status-change broadcast failed")
 	// KV publish ran and succeeded — the failure was the second-stage broadcast.
 	if len(pub.configCalls) != 1 {
 		t.Errorf("PublishMarketConfig called %d times, want 1", len(pub.configCalls))
@@ -1455,7 +1450,7 @@ func TestHandler_GetMarket_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "not found")
+	testassert.BodyContains(t, rec, "not found")
 }
 
 func TestHandler_UpdateMarket_KVPublishFailureReturns502(t *testing.T) {
@@ -1475,7 +1470,7 @@ func TestHandler_UpdateMarket_KVPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", rec.Code)
 	}
-	assertBodyContains(t, rec, "config publish failed")
+	testassert.BodyContains(t, rec, "config publish failed")
 }
 
 func TestHandler_SetFeeRate_PublishesConfig(t *testing.T) {
@@ -1507,7 +1502,7 @@ func TestHandler_SetFeeRate_KVPublishFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", rec.Code)
 	}
-	assertBodyContains(t, rec, "config publish failed")
+	testassert.BodyContains(t, rec, "config publish failed")
 }
 
 func TestHandler_MethodNotAllowed(t *testing.T) {
@@ -1650,7 +1645,7 @@ func TestHandler_CreateEvent_Binary_MissingQuestionID(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
-	assertBodyContains(t, rec, "question_id is required")
+	testassert.BodyContains(t, rec, "question_id is required")
 }
 
 func TestHandler_CreateEvent_Binary_EmptyMarkets(t *testing.T) {
@@ -1671,7 +1666,7 @@ func TestHandler_CreateEvent_Binary_EmptyMarkets(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
-	assertBodyContains(t, rec, "markets is required")
+	testassert.BodyContains(t, rec, "markets is required")
 }
 
 func TestHandler_CreateEvent_Binary_OnChainNotPrepared(t *testing.T) {
@@ -1856,7 +1851,7 @@ func TestHandler_CreateEvent_Binary_TokenIDChainError(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("status = %d body=%q, want 502", rec.Code, rec.Body.String())
 	}
-	assertBodyContains(t, rec, "chain read failed")
+	testassert.BodyContains(t, rec, "chain read failed")
 }
 
 // --- /admin/events POST (NEG_RISK) --------------------------------------
@@ -1963,7 +1958,7 @@ func TestHandler_CreateEvent_NegRisk_MissingMarketID(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
-	assertBodyContains(t, rec, "neg_risk_market_id is required")
+	testassert.BodyContains(t, rec, "neg_risk_market_id is required")
 }
 
 func TestHandler_CreateEvent_NegRisk_SingleMarket(t *testing.T) {
@@ -1987,7 +1982,7 @@ func TestHandler_CreateEvent_NegRisk_SingleMarket(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
-	assertBodyContains(t, rec, "at least 2 markets")
+	testassert.BodyContains(t, rec, "at least 2 markets")
 }
 
 // --- /admin/events/{id}/resolve -----------------------------------------
@@ -2136,7 +2131,7 @@ func TestHandler_ResolveEvent_EventNotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "event not found")
+	testassert.BodyContains(t, rec, "event not found")
 }
 
 func TestHandler_ResolveEvent_NegRiskFriendlyError(t *testing.T) {
@@ -2371,7 +2366,7 @@ func TestHandler_SetTradingConfig_InvalidTickSize(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
-	assertBodyContains(t, rec, "invalid tick_size")
+	testassert.BodyContains(t, rec, "invalid tick_size")
 }
 
 func TestHandler_SetTradingConfig_NotFound(t *testing.T) {
@@ -2383,7 +2378,7 @@ func TestHandler_SetTradingConfig_NotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
 	}
-	assertBodyContains(t, rec, "not found")
+	testassert.BodyContains(t, rec, "not found")
 }
 
 func TestHandler_SetTradingConfig_PublishFailure(t *testing.T) {
@@ -2398,7 +2393,7 @@ func TestHandler_SetTradingConfig_PublishFailure(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("status = %d, want 502", rec.Code)
 	}
-	assertBodyContains(t, rec, "config publish failed")
+	testassert.BodyContains(t, rec, "config publish failed")
 }
 
 // --- live-status overlay on GET /admin/markets/{id} ----------------------
@@ -2460,7 +2455,7 @@ func TestHandler_GetMarket_BucketReadFailureReturns502(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("status = %d, want 502", rec.Code)
 	}
-	assertBodyContains(t, rec, "reading live market config failed")
+	testassert.BodyContains(t, rec, "reading live market config failed")
 }
 
 // --- idempotent retry after a failed publish ------------------------------
@@ -2494,7 +2489,7 @@ func TestHandler_ResolveEvent_RetrySameOutcomeRepublishes(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("first resolve status = %d, want 502", rec.Code)
 	}
-	assertBodyContains(t, rec, "config publish failed")
+	testassert.BodyContains(t, rec, "config publish failed")
 	if repo.markets[marketID].Status != StatusResolved {
 		t.Fatalf("market status = %s, want RESOLVED (DB committed before publish)",
 			repo.markets[marketID].Status)
@@ -2551,7 +2546,7 @@ func TestHandler_ResolveEvent_RetryDifferentOutcomeConflicts(t *testing.T) {
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Errorf("conflicting retry status = %d, want 422", rec.Code)
 	}
-	assertBodyContains(t, rec, "on-chain numerators")
+	testassert.BodyContains(t, rec, "on-chain numerators")
 }
 
 func TestHandler_VoidEvent_RetryRepublishes(t *testing.T) {
@@ -2582,7 +2577,7 @@ func TestHandler_VoidEvent_RetryRepublishes(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("first void status = %d, want 502", rec.Code)
 	}
-	assertBodyContains(t, rec, "config publish failed")
+	testassert.BodyContains(t, rec, "config publish failed")
 
 	pub.configErr = nil
 	pub.configCalls = nil

--- a/internal/shared/httputil/middleware_test.go
+++ b/internal/shared/httputil/middleware_test.go
@@ -87,6 +87,8 @@ func TestLogging_CapturesStatusCode(t *testing.T) {
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
 	}
+	// Logging is pass-through middleware: the wrapped handler owns the response
+	// body, so there is no failure-reason body for this status-only check to pin.
 }
 
 func TestRecovery_HandlerPanic(t *testing.T) {

--- a/internal/shared/ratelimit/middleware_test.go
+++ b/internal/shared/ratelimit/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,8 +79,8 @@ func TestMiddleware_Returns429WithRetryAfter(t *testing.T) {
 	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decoding body: %v", err)
 	}
-	if body["error"] == "" {
-		t.Fatalf("expected error envelope, got %v", body)
+	if body["error"] != "too many requests" {
+		t.Fatalf("error = %q, want %q", body["error"], "too many requests")
 	}
 }
 
@@ -109,6 +110,9 @@ func TestMiddleware_LockoutShortCircuits(t *testing.T) {
 	if recorder.Code != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want 429", recorder.Code)
 	}
+	if !strings.Contains(recorder.Body.String(), "too many requests") {
+		t.Errorf("body = %q, want rate-limit rejection reason", recorder.Body.String())
+	}
 	if called {
 		t.Fatal("handler should not be invoked when locked out")
 	}
@@ -130,6 +134,9 @@ func TestMiddleware_KeyByUserFallsBackToIP(t *testing.T) {
 	handler.ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want 429 (IP-keyed)", recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), "too many requests") {
+		t.Errorf("body = %q, want rate-limit rejection reason", recorder.Body.String())
 	}
 
 	// Different user on same IP — different bucket, should pass.

--- a/internal/shared/testassert/http.go
+++ b/internal/shared/testassert/http.go
@@ -1,0 +1,16 @@
+// Package testassert provides shared assertion helpers for tests.
+package testassert
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// BodyContains asserts that an HTTP test response body contains want.
+func BodyContains(t *testing.T, recorder *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	if !strings.Contains(recorder.Body.String(), want) {
+		t.Errorf("body = %q, want substring %q", recorder.Body.String(), want)
+	}
+}

--- a/internal/trading/auth/handler_test.go
+++ b/internal/trading/auth/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/Shisa-Fosho/services/internal/platform/data"
+	"github.com/Shisa-Fosho/services/internal/shared/testassert"
 )
 
 // fakeRepo is an in-memory APIKeyRepository implementation for tests.
@@ -113,13 +114,6 @@ func keysOf(m map[string]interface{}) []string {
 		out = append(out, key)
 	}
 	return out
-}
-
-func assertBodyContains(t *testing.T, recorder *httptest.ResponseRecorder, want string) {
-	t.Helper()
-	if !strings.Contains(recorder.Body.String(), want) {
-		t.Errorf("body = %q, want substring %q", recorder.Body.String(), want)
-	}
 }
 
 // ---------------------------------------------------------------------------
@@ -241,7 +235,7 @@ func TestDeriveAPIKey_MissingHeaders(t *testing.T) {
 	if recorder.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
-	assertBodyContains(t, recorder, "POLY_ADDRESS")
+	testassert.BodyContains(t, recorder, "POLY_ADDRESS")
 }
 
 func TestDeriveAPIKey_InvalidSignature(t *testing.T) {
@@ -261,7 +255,7 @@ func TestDeriveAPIKey_InvalidSignature(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
-	assertBodyContains(t, recorder, "signature verification failed")
+	testassert.BodyContains(t, recorder, "signature verification failed")
 }
 
 func TestDeriveAPIKey_Idempotent(t *testing.T) {
@@ -395,7 +389,7 @@ func TestRevokeAPIKey_NotFound(t *testing.T) {
 	if recorder.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusNotFound)
 	}
-	assertBodyContains(t, recorder, "api key not found")
+	testassert.BodyContains(t, recorder, "api key not found")
 }
 
 func TestRevokeAPIKey_MissingField(t *testing.T) {
@@ -418,7 +412,7 @@ func TestRevokeAPIKey_MissingField(t *testing.T) {
 	if recorder.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
-	assertBodyContains(t, recorder, "api_key is required")
+	testassert.BodyContains(t, recorder, "api_key is required")
 }
 
 func TestRevokeAPIKey_RejectsJWT(t *testing.T) {
@@ -438,7 +432,7 @@ func TestRevokeAPIKey_RejectsJWT(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d; CLOB routes must not accept JWT", recorder.Code, http.StatusUnauthorized)
 	}
-	assertBodyContains(t, recorder, "POLY_API_KEY")
+	testassert.BodyContains(t, recorder, "POLY_API_KEY")
 }
 
 // ---------------------------------------------------------------------------
@@ -529,5 +523,5 @@ func TestListAPIKeys_RejectsJWT(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d; CLOB routes must not accept JWT", recorder.Code, http.StatusUnauthorized)
 	}
-	assertBodyContains(t, recorder, "POLY_API_KEY")
+	testassert.BodyContains(t, recorder, "POLY_API_KEY")
 }

--- a/internal/trading/auth/handler_test.go
+++ b/internal/trading/auth/handler_test.go
@@ -115,6 +115,13 @@ func keysOf(m map[string]interface{}) []string {
 	return out
 }
 
+func assertBodyContains(t *testing.T, recorder *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	if !strings.Contains(recorder.Body.String(), want) {
+		t.Errorf("body = %q, want substring %q", recorder.Body.String(), want)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GET /auth/derive-api-key
 // ---------------------------------------------------------------------------
@@ -234,6 +241,7 @@ func TestDeriveAPIKey_MissingHeaders(t *testing.T) {
 	if recorder.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
+	assertBodyContains(t, recorder, "POLY_ADDRESS")
 }
 
 func TestDeriveAPIKey_InvalidSignature(t *testing.T) {
@@ -253,6 +261,7 @@ func TestDeriveAPIKey_InvalidSignature(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
 	}
+	assertBodyContains(t, recorder, "signature verification failed")
 }
 
 func TestDeriveAPIKey_Idempotent(t *testing.T) {
@@ -386,6 +395,7 @@ func TestRevokeAPIKey_NotFound(t *testing.T) {
 	if recorder.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusNotFound)
 	}
+	assertBodyContains(t, recorder, "api key not found")
 }
 
 func TestRevokeAPIKey_MissingField(t *testing.T) {
@@ -408,6 +418,7 @@ func TestRevokeAPIKey_MissingField(t *testing.T) {
 	if recorder.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
+	assertBodyContains(t, recorder, "api_key is required")
 }
 
 func TestRevokeAPIKey_RejectsJWT(t *testing.T) {
@@ -427,6 +438,7 @@ func TestRevokeAPIKey_RejectsJWT(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d; CLOB routes must not accept JWT", recorder.Code, http.StatusUnauthorized)
 	}
+	assertBodyContains(t, recorder, "POLY_API_KEY")
 }
 
 // ---------------------------------------------------------------------------
@@ -517,4 +529,5 @@ func TestListAPIKeys_RejectsJWT(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d; CLOB routes must not accept JWT", recorder.Code, http.StatusUnauthorized)
 	}
+	assertBodyContains(t, recorder, "POLY_API_KEY")
 }


### PR DESCRIPTION
## Summary
- audited remaining status-only error-path tests across platform auth, trading auth, market handlers, shared rate-limit, and HTTP middleware tests
- added response-body reason assertions where the handler owns the error body
- documented the few generic/pass-through cases where no handler-specific reason is assertable

Closes #88

## Verification
- `make test` ✅
- `GOFLAGS=-buildvcs=false make lint` ✅
- `make test-onchain` blocked: Docker is not installed in this environment (`/bin/sh: 1: docker: not found`)
- independent pre-commit reviewer passed ✅