### PR TITLE
fix: use pinned staging SSH known hosts

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -109,11 +109,16 @@ jobs:
           SSH_KEY: ${{ secrets.STAGING_DEPLOY_SSH_KEY }}
           DEPLOY_HOST: ${{ secrets.STAGING_DEPLOY_HOST }}
           DEPLOY_PORT: ${{ secrets.STAGING_DEPLOY_PORT }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.STAGING_DEPLOY_KNOWN_HOSTS }}
         run: |
           install -m 700 -d ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/shisa_staging
           chmod 600 ~/.ssh/shisa_staging
-          ssh-keyscan -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          if [ -n "$DEPLOY_KNOWN_HOSTS" ]; then
+            printf '%s\n' "$DEPLOY_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+          else
+            ssh-keyscan -T 30 -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          fi
 
       - name: Render staging environment file
         env:


### PR DESCRIPTION
## Summary
- Use `STAGING_DEPLOY_KNOWN_HOSTS` when present instead of requiring `ssh-keyscan` from GitHub-hosted runners.
- Keep a `ssh-keyscan -T 30` fallback for environments without a pinned known-hosts secret.

## Verification
- `actionlint .github/workflows/staging.yml`

This fixes the first staging deploy failure after #90 merged: the GitHub runner failed during `ssh-keyscan` even though the VPS SSH host key is reachable and now stored as the `STAGING_DEPLOY_KNOWN_HOSTS` environment secret.
