### PR TITLE
feat: add markets to existing events

### DIFF
--- a/internal/platform/market/handler.go
+++ b/internal/platform/market/handler.go
@@ -63,6 +63,8 @@ func (handler *Handler) RegisterAdminRoutes(mux *http.ServeMux, adminMiddleware 
 
 	mux.Handle("POST /admin/events/binary", adminMiddleware(http.HandlerFunc(handler.createBinaryEvent)))
 	mux.Handle("POST /admin/events/neg-risk", adminMiddleware(http.HandlerFunc(handler.createNegRiskEvent)))
+	mux.Handle("POST /admin/events/{id}/binary/markets", adminMiddleware(http.HandlerFunc(handler.addBinaryMarkets)))
+	mux.Handle("POST /admin/events/{id}/neg-risk/markets", adminMiddleware(http.HandlerFunc(handler.addNegRiskMarkets)))
 	mux.Handle("PUT /admin/events/{id}", adminMiddleware(http.HandlerFunc(handler.updateEvent)))
 	mux.Handle("POST /admin/events/{id}/binary/resolve", adminMiddleware(http.HandlerFunc(handler.resolveBinaryEvent)))
 	mux.Handle("POST /admin/events/{id}/neg-risk/resolve", adminMiddleware(http.HandlerFunc(handler.resolveNegRiskEvent)))

--- a/internal/platform/market/handler_events_add_markets.go
+++ b/internal/platform/market/handler_events_add_markets.go
@@ -1,0 +1,262 @@
+package market
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/Shisa-Fosho/services/internal/shared/eth"
+	"github.com/Shisa-Fosho/services/internal/shared/httputil"
+)
+
+type addBinaryMarketsRequest struct {
+	Markets []createBinaryMarketSubobject `json:"markets"`
+}
+
+type addNegRiskMarketsRequest struct {
+	Markets []createNegRiskMarketSubobject `json:"markets"`
+}
+
+func (handler *Handler) addBinaryMarkets(w http.ResponseWriter, r *http.Request) {
+	event, ok := handler.loadEventForMarketAppend(r.Context(), w, r.PathValue("id"), EventTypeBinary)
+	if !ok {
+		return
+	}
+	var req addBinaryMarketsRequest
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	markets, ok := handler.binaryMarketsFromSubobjects(w, req.Markets)
+	if !ok {
+		return
+	}
+	if !handler.verifyOutcomeSlotCounts(r.Context(), w, markets) {
+		return
+	}
+	if !handler.verifyBinaryTokenIDs(r.Context(), w, markets) {
+		return
+	}
+	handler.finishAddMarkets(r.Context(), w, event.ID, markets)
+}
+
+func (handler *Handler) addNegRiskMarkets(w http.ResponseWriter, r *http.Request) {
+	event, ok := handler.loadEventForMarketAppend(r.Context(), w, r.PathValue("id"), EventTypeNegRisk)
+	if !ok {
+		return
+	}
+	var req addNegRiskMarketsRequest
+	if err := httputil.DecodeJSON(r, &req); err != nil {
+		httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	markets, ok := handler.negRiskMarketsFromSubobjects(w, req.Markets, *event.NegRiskMarketID)
+	if !ok {
+		return
+	}
+	for idx, market := range markets {
+		qid := common.HexToHash(market.QuestionID)
+		cid, err := handler.negRisk.ConditionID(r.Context(), qid)
+		if err != nil {
+			if errors.Is(err, eth.ErrNegRiskDisabled) {
+				httputil.ErrorResponse(w, http.StatusBadGateway,
+					"neg-risk adapter not configured on this deploy")
+				return
+			}
+			handler.chainError(w, fmt.Sprintf("deriving neg-risk condition_id for markets[%d]", idx), err)
+			return
+		}
+		market.ConditionID = cid.Hex()
+	}
+	if !handler.verifyOutcomeSlotCounts(r.Context(), w, markets) {
+		return
+	}
+	if !handler.verifyNegRiskTokenIDs(r.Context(), w, markets) {
+		return
+	}
+	handler.finishAddMarkets(r.Context(), w, event.ID, markets)
+}
+
+func (handler *Handler) loadEventForMarketAppend(ctx context.Context, w http.ResponseWriter, eventID string, expected EventType) (*Event, bool) {
+	if eventID == "" {
+		httputil.ErrorResponse(w, http.StatusBadRequest, "id is required")
+		return nil, false
+	}
+	event, err := handler.repo.GetEvent(ctx, eventID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			httputil.ErrorResponse(w, http.StatusNotFound, "event not found")
+			return nil, false
+		}
+		handler.internalError(w, "loading event", err)
+		return nil, false
+	}
+	if event.EventType != expected {
+		httputil.ErrorResponse(w, http.StatusUnprocessableEntity,
+			fmt.Sprintf("event %s is %s, not %s", eventID, event.EventType.String(), expected.String()))
+		return nil, false
+	}
+	if event.Status.IsTerminal() {
+		httputil.ErrorResponse(w, http.StatusConflict,
+			fmt.Sprintf("event %s is terminal (%s)", eventID, event.Status.String()))
+		return nil, false
+	}
+	return event, true
+}
+
+func (handler *Handler) binaryMarketsFromSubobjects(w http.ResponseWriter, reqMarkets []createBinaryMarketSubobject) ([]*Market, bool) {
+	if len(reqMarkets) == 0 {
+		httputil.ErrorResponse(w, http.StatusBadRequest, "markets is required")
+		return nil, false
+	}
+	markets := make([]*Market, 0, len(reqMarkets))
+	for idx, marketReq := range reqMarkets {
+		if marketReq.ConditionID == "" {
+			httputil.ErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("markets[%d].condition_id is required", idx))
+			return nil, false
+		}
+		if !isHexHash(marketReq.ConditionID) {
+			httputil.ErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("markets[%d].condition_id must be a 0x-prefixed 32-byte hex string", idx))
+			return nil, false
+		}
+		if marketReq.QuestionID == "" {
+			httputil.ErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("markets[%d].question_id is required", idx))
+			return nil, false
+		}
+		if !isHexHash(marketReq.QuestionID) {
+			httputil.ErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("markets[%d].question_id must be a 0x-prefixed 32-byte hex string", idx))
+			return nil, false
+		}
+		market, ok := marketFromBinarySubobject(w, idx, marketReq)
+		if !ok {
+			return nil, false
+		}
+		markets = append(markets, market)
+	}
+	return markets, true
+}
+
+func (handler *Handler) negRiskMarketsFromSubobjects(w http.ResponseWriter, reqMarkets []createNegRiskMarketSubobject, negRiskMarketID string) ([]*Market, bool) {
+	if len(reqMarkets) == 0 {
+		httputil.ErrorResponse(w, http.StatusBadRequest, "markets is required")
+		return nil, false
+	}
+	adapterMarketID := common.HexToHash(negRiskMarketID)
+	markets := make([]*Market, 0, len(reqMarkets))
+	for idx, marketReq := range reqMarkets {
+		if marketReq.QuestionID == "" {
+			httputil.ErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("markets[%d].question_id is required", idx))
+			return nil, false
+		}
+		if !isHexHash(marketReq.QuestionID) {
+			httputil.ErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("markets[%d].question_id must be a 0x-prefixed 32-byte hex string", idx))
+			return nil, false
+		}
+		if negRiskMarketIDOf(common.HexToHash(marketReq.QuestionID)) != adapterMarketID {
+			httputil.ErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("markets[%d].question_id does not belong to neg_risk_market_id (first 31 bytes must match)", idx))
+			return nil, false
+		}
+		market, ok := marketFromNegRiskSubobject(w, idx, marketReq)
+		if !ok {
+			return nil, false
+		}
+		markets = append(markets, market)
+	}
+	return markets, true
+}
+
+func marketFromBinarySubobject(w http.ResponseWriter, idx int, marketReq createBinaryMarketSubobject) (*Market, bool) {
+	if !validTokenIDs(w, idx, marketReq.TokenIDYes, marketReq.TokenIDNo) {
+		return nil, false
+	}
+	tickSize, ok := ParseTickSize(marketReq.TickSize)
+	if !ok {
+		httputil.ErrorResponse(w, http.StatusBadRequest,
+			fmt.Sprintf("markets[%d].tick_size %q is invalid", idx, marketReq.TickSize))
+		return nil, false
+	}
+	return &Market{
+		Slug:            marketReq.Slug,
+		Question:        marketReq.Question,
+		OutcomeYesLabel: marketReq.OutcomeYesLabel,
+		OutcomeNoLabel:  marketReq.OutcomeNoLabel,
+		TokenIDYes:      marketReq.TokenIDYes,
+		TokenIDNo:       marketReq.TokenIDNo,
+		ConditionID:     marketReq.ConditionID,
+		QuestionID:      marketReq.QuestionID,
+		Status:          StatusActive,
+		TickSize:        tickSize,
+		MinSize:         marketReq.MinSize,
+		MaxSize:         marketReq.MaxSize,
+		FeeRateBps:      marketReq.FeeRateBps,
+	}, true
+}
+
+func marketFromNegRiskSubobject(w http.ResponseWriter, idx int, marketReq createNegRiskMarketSubobject) (*Market, bool) {
+	if !validTokenIDs(w, idx, marketReq.TokenIDYes, marketReq.TokenIDNo) {
+		return nil, false
+	}
+	tickSize, ok := ParseTickSize(marketReq.TickSize)
+	if !ok {
+		httputil.ErrorResponse(w, http.StatusBadRequest,
+			fmt.Sprintf("markets[%d].tick_size %q is invalid", idx, marketReq.TickSize))
+		return nil, false
+	}
+	return &Market{
+		Slug:            marketReq.Slug,
+		Question:        marketReq.Question,
+		OutcomeYesLabel: marketReq.OutcomeYesLabel,
+		OutcomeNoLabel:  marketReq.OutcomeNoLabel,
+		TokenIDYes:      marketReq.TokenIDYes,
+		TokenIDNo:       marketReq.TokenIDNo,
+		QuestionID:      marketReq.QuestionID,
+		Status:          StatusActive,
+		TickSize:        tickSize,
+		MinSize:         marketReq.MinSize,
+		MaxSize:         marketReq.MaxSize,
+		FeeRateBps:      marketReq.FeeRateBps,
+	}, true
+}
+
+func (handler *Handler) finishAddMarkets(ctx context.Context, w http.ResponseWriter, eventID string, markets []*Market) {
+	updatedEvent, addedMarkets, err := handler.repo.AddMarketsToEvent(ctx, eventID, markets)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrNotFound):
+			httputil.ErrorResponse(w, http.StatusNotFound, "event not found")
+		case errors.Is(err, ErrDuplicateSlug):
+			httputil.ErrorResponse(w, http.StatusConflict, "slug, condition_id, or question_id already in use")
+		case errors.Is(err, ErrInvalidTransition):
+			httputil.ErrorResponse(w, http.StatusConflict, err.Error())
+		case errors.Is(err, ErrInvalidEvent):
+			httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, ErrInvalidMarket):
+			httputil.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		default:
+			handler.internalError(w, "adding markets to event", err)
+		}
+		return
+	}
+	for _, market := range addedMarkets {
+		if err := handler.publisher.PublishMarketConfig(market); err != nil {
+			handler.publishFailed(w, "market-config after market append",
+				"markets added but config publish failed; please retry", market.ID, err)
+			return
+		}
+	}
+	resp := eventWithMarketsResponse{Event: toEventResponse(updatedEvent)}
+	for _, market := range addedMarkets {
+		resp.Markets = append(resp.Markets, toMarketResponse(market))
+	}
+	_ = httputil.EncodeJSON(w, http.StatusCreated, resp)
+}

--- a/internal/platform/market/handler_test.go
+++ b/internal/platform/market/handler_test.go
@@ -280,6 +280,48 @@ func (f *fakeRepo) CreateEventWithMarkets(_ context.Context, event *Event, marke
 	return storedEvent, storedMarkets, nil
 }
 
+func (f *fakeRepo) AddMarketsToEvent(_ context.Context, eventID string, markets []*Market) (*Event, []*Market, error) {
+	event, ok := f.events[eventID]
+	if !ok {
+		return nil, nil, ErrNotFound
+	}
+	if event.Status.IsTerminal() {
+		return nil, nil, ErrInvalidTransition
+	}
+	if len(markets) == 0 {
+		return nil, nil, ErrInvalidMarket
+	}
+	out := make([]*Market, 0, len(markets))
+	for _, market := range markets {
+		market.EventID = eventID
+		market.Status = StatusActive
+		if err := ValidateMarket(market); err != nil {
+			return nil, nil, err
+		}
+		var existing *Market
+		for _, stored := range f.markets {
+			if stored.EventID == eventID && (stored.Slug == market.Slug || stored.ConditionID == market.ConditionID || stored.QuestionID == market.QuestionID) {
+				existing = stored
+				break
+			}
+			if stored.Slug == market.Slug || stored.ConditionID == market.ConditionID || stored.QuestionID == market.QuestionID {
+				return nil, nil, ErrDuplicateSlug
+			}
+		}
+		if existing != nil {
+			if !sameAppendMarket(existing, market) {
+				return nil, nil, ErrDuplicateSlug
+			}
+			cp := *existing
+			out = append(out, &cp)
+			continue
+		}
+		out = append(out, f.putMarket(market))
+	}
+	eventCopy := *event
+	return &eventCopy, out, nil
+}
+
 func (f *fakeRepo) GetEvent(_ context.Context, id string) (*Event, error) {
 	e, ok := f.events[id]
 	if !ok {
@@ -1983,6 +2025,254 @@ func TestHandler_CreateEvent_NegRisk_SingleMarket(t *testing.T) {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
 	testassert.BodyContains(t, rec, "at least 2 markets")
+}
+
+// --- /admin/events/{id}/{binary|neg-risk}/markets ------------------------
+
+func TestHandler_AddMarkets_Binary_Success(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	catID := seedCatID(t, repo, "add-bin")
+	pub := &fakePublisher{}
+	chain := newFakeChainReader()
+	c1 := fixedCondHash("add-b1")
+	c2 := fixedCondHash("add-b2")
+	chain.slotCount[common.HexToHash(c1)] = 2
+	chain.slotCount[common.HexToHash(c2)] = 2
+	mux := muxWithChain(t, repo, pub, chain)
+
+	rec := doRequest(t, mux, http.MethodPost, "/admin/events/binary",
+		binaryEventBody("add-bin", catID, c1, fixedCondHash("add-bq1")))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("setup: %d %s", rec.Code, rec.Body.String())
+	}
+	var created eventWithMarketsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+	pub.configCalls = nil
+
+	body := []byte(`{"markets":[{"slug":"add-bin-m2","question":"Second?","outcome_yes_label":"Yes","outcome_no_label":"No",` + tokenIDsJSON(c2) + `,"condition_id":"` + c2 + `","question_id":"` + fixedCondHash("add-bq2") + `","tick_size":"0.01","min_size":5}]}`)
+	rec = doRequest(t, mux, http.MethodPost, "/admin/events/"+created.Event.ID+"/binary/markets", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d body=%q, want 201", rec.Code, rec.Body.String())
+	}
+	if len(pub.configCalls) != 1 {
+		t.Errorf("PublishMarketConfig calls = %d, want 1", len(pub.configCalls))
+	}
+	var resp eventWithMarketsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Markets) != 1 || resp.Markets[0].Slug != "add-bin-m2" {
+		t.Fatalf("response markets = %+v, want appended market", resp.Markets)
+	}
+}
+
+func TestHandler_AddMarkets_EventTypeMismatch(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	catID := seedCatID(t, repo, "add-mismatch")
+	pub := &fakePublisher{}
+	chain := newFakeChainReader()
+	c1 := fixedCondHash("add-mm1")
+	c2 := fixedCondHash("add-mm2")
+	chain.slotCount[common.HexToHash(c1)] = 2
+	chain.slotCount[common.HexToHash(c2)] = 2
+	mux := muxWithChain(t, repo, pub, chain)
+
+	rec := doRequest(t, mux, http.MethodPost, "/admin/events/binary",
+		binaryEventBody("add-mismatch", catID, c1, fixedCondHash("add-mmq1")))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("setup: %d %s", rec.Code, rec.Body.String())
+	}
+	var created eventWithMarketsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	body := []byte(`{"markets":[{"slug":"wrong","question":"Wrong?","outcome_yes_label":"Yes","outcome_no_label":"No",` + tokenIDsJSON(negRiskQuestionID(negRiskMarketIDHex("wrong"), 0)) + `,"question_id":"` + negRiskQuestionID(negRiskMarketIDHex("wrong"), 0) + `","tick_size":"0.01","min_size":5}]}`)
+	rec = doRequest(t, mux, http.MethodPost, "/admin/events/"+created.Event.ID+"/neg-risk/markets", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d body=%q, want 422", rec.Code, rec.Body.String())
+	}
+	testassert.BodyContains(t, rec, "not NEG_RISK")
+}
+
+func TestHandler_AddMarkets_NegRisk_Success(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	catID := seedCatID(t, repo, "add-neg-ok")
+	pub := &fakePublisher{}
+	chain := newFakeChainReader()
+	negID := negRiskMarketIDHex("add-neg-ok")
+	q1 := negRiskQuestionID(negID, 0)
+	q2 := negRiskQuestionID(negID, 1)
+	q3 := negRiskQuestionID(negID, 2)
+	c1 := common.HexToHash(fixedCondHash("add-ok-c1"))
+	c2 := common.HexToHash(fixedCondHash("add-ok-c2"))
+	c3 := common.HexToHash(fixedCondHash("add-ok-c3"))
+	chain.negRiskCondIDs[common.HexToHash(q1)] = c1
+	chain.negRiskCondIDs[common.HexToHash(q2)] = c2
+	chain.negRiskCondIDs[common.HexToHash(q3)] = c3
+	chain.slotCount[c1] = 2
+	chain.slotCount[c2] = 2
+	chain.slotCount[c3] = 2
+	mux := muxWithChain(t, repo, pub, chain)
+
+	createBody := []byte(`{"slug":"add-neg-ok","title":"T","description":"D","category_id":"` + catID + `","end_date":"` + time.Now().Add(24*time.Hour).UTC().Format(time.RFC3339) + `","neg_risk_market_id":"` + negID + `","markets":[{"slug":"a","question":"?","outcome_yes_label":"Y","outcome_no_label":"N",` + tokenIDsJSON(q1) + `,"question_id":"` + q1 + `","tick_size":"0.01","min_size":5},{"slug":"b","question":"?","outcome_yes_label":"Y","outcome_no_label":"N",` + tokenIDsJSON(q2) + `,"question_id":"` + q2 + `","tick_size":"0.01","min_size":5}]}`)
+	rec := doRequest(t, mux, http.MethodPost, "/admin/events/neg-risk", createBody)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("setup: %d %s", rec.Code, rec.Body.String())
+	}
+	var created eventWithMarketsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+	pub.configCalls = nil
+
+	body := []byte(`{"markets":[{"slug":"c","question":"Third?","outcome_yes_label":"Yes","outcome_no_label":"No",` + tokenIDsJSON(q3) + `,"question_id":"` + q3 + `","tick_size":"0.01","min_size":5}]}`)
+	rec = doRequest(t, mux, http.MethodPost, "/admin/events/"+created.Event.ID+"/neg-risk/markets", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d body=%q, want 201", rec.Code, rec.Body.String())
+	}
+	if len(pub.configCalls) != 1 {
+		t.Errorf("PublishMarketConfig calls = %d, want 1", len(pub.configCalls))
+	}
+	var resp eventWithMarketsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Markets) != 1 || resp.Markets[0].ConditionID != c3.Hex() {
+		t.Fatalf("response markets = %+v, want appended market with derived condition_id %s", resp.Markets, c3.Hex())
+	}
+}
+
+func TestHandler_AddMarkets_TerminalEventRejected(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	catID := seedCatID(t, repo, "add-terminal")
+	pub := &fakePublisher{}
+	chain := newFakeChainReader()
+	c1 := fixedCondHash("add-t1")
+	c2 := fixedCondHash("add-t2")
+	chain.slotCount[common.HexToHash(c1)] = 2
+	chain.slotCount[common.HexToHash(c2)] = 2
+	mux := muxWithChain(t, repo, pub, chain)
+
+	rec := doRequest(t, mux, http.MethodPost, "/admin/events/binary",
+		binaryEventBody("add-terminal", catID, c1, fixedCondHash("add-tq1")))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("setup: %d %s", rec.Code, rec.Body.String())
+	}
+	var created eventWithMarketsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+	repo.events[created.Event.ID].Status = StatusResolved
+
+	body := []byte(`{"markets":[{"slug":"term-m2","question":"Second?","outcome_yes_label":"Yes","outcome_no_label":"No",` + tokenIDsJSON(c2) + `,"condition_id":"` + c2 + `","question_id":"` + fixedCondHash("add-tq2") + `","tick_size":"0.01","min_size":5}]}`)
+	rec = doRequest(t, mux, http.MethodPost, "/admin/events/"+created.Event.ID+"/binary/markets", body)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d body=%q, want 409", rec.Code, rec.Body.String())
+	}
+	testassert.BodyContains(t, rec, "terminal")
+}
+
+func TestHandler_AddMarkets_DuplicateSlugConflicts(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	catID := seedCatID(t, repo, "add-dupe")
+	pub := &fakePublisher{}
+	chain := newFakeChainReader()
+	c1 := fixedCondHash("add-d1")
+	c2 := fixedCondHash("add-d2")
+	chain.slotCount[common.HexToHash(c1)] = 2
+	chain.slotCount[common.HexToHash(c2)] = 2
+	mux := muxWithChain(t, repo, pub, chain)
+
+	rec := doRequest(t, mux, http.MethodPost, "/admin/events/binary",
+		binaryEventBody("add-dupe", catID, c1, fixedCondHash("add-dq1")))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("setup: %d %s", rec.Code, rec.Body.String())
+	}
+	var created eventWithMarketsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	body := []byte(`{"markets":[{"slug":"add-dupe-m1","question":"Different?","outcome_yes_label":"Yes","outcome_no_label":"No",` + tokenIDsJSON(c2) + `,"condition_id":"` + c2 + `","question_id":"` + fixedCondHash("add-dq2") + `","tick_size":"0.01","min_size":5}]}`)
+	rec = doRequest(t, mux, http.MethodPost, "/admin/events/"+created.Event.ID+"/binary/markets", body)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d body=%q, want 409", rec.Code, rec.Body.String())
+	}
+	testassert.BodyContains(t, rec, "already in use")
+}
+
+func TestHandler_AddMarkets_NegRiskQuestionIDFromDifferentMarket(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	catID := seedCatID(t, repo, "add-neg")
+	pub := &fakePublisher{}
+	chain := newFakeChainReader()
+	negID := negRiskMarketIDHex("add-neg")
+	q1 := negRiskQuestionID(negID, 0)
+	q2 := negRiskQuestionID(negID, 1)
+	c1 := common.HexToHash(fixedCondHash("add-nc1"))
+	c2 := common.HexToHash(fixedCondHash("add-nc2"))
+	chain.negRiskCondIDs[common.HexToHash(q1)] = c1
+	chain.negRiskCondIDs[common.HexToHash(q2)] = c2
+	chain.slotCount[c1] = 2
+	chain.slotCount[c2] = 2
+	mux := muxWithChain(t, repo, pub, chain)
+
+	createBody := []byte(`{"slug":"add-neg","title":"T","description":"D","category_id":"` + catID + `","end_date":"` + time.Now().Add(24*time.Hour).UTC().Format(time.RFC3339) + `","neg_risk_market_id":"` + negID + `","markets":[{"slug":"a","question":"?","outcome_yes_label":"Y","outcome_no_label":"N",` + tokenIDsJSON(q1) + `,"question_id":"` + q1 + `","tick_size":"0.01","min_size":5},{"slug":"b","question":"?","outcome_yes_label":"Y","outcome_no_label":"N",` + tokenIDsJSON(q2) + `,"question_id":"` + q2 + `","tick_size":"0.01","min_size":5}]}`)
+	rec := doRequest(t, mux, http.MethodPost, "/admin/events/neg-risk", createBody)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("setup: %d %s", rec.Code, rec.Body.String())
+	}
+	var created eventWithMarketsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	foreignID := negRiskMarketIDHex("foreign-add")
+	foreignQuestion := negRiskQuestionID(foreignID, 2)
+	body := []byte(`{"markets":[{"slug":"foreign","question":"Foreign?","outcome_yes_label":"Yes","outcome_no_label":"No",` + tokenIDsJSON(foreignQuestion) + `,"question_id":"` + foreignQuestion + `","tick_size":"0.01","min_size":5}]}`)
+	rec = doRequest(t, mux, http.MethodPost, "/admin/events/"+created.Event.ID+"/neg-risk/markets", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%q, want 400", rec.Code, rec.Body.String())
+	}
+	testassert.BodyContains(t, rec, "does not belong to neg_risk_market_id")
+}
+
+func TestHandler_AddMarkets_RetryAfterPublishFailureRepublishes(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo()
+	catID := seedCatID(t, repo, "add-retry")
+	pub := &fakePublisher{}
+	chain := newFakeChainReader()
+	c1 := fixedCondHash("add-r1")
+	c2 := fixedCondHash("add-r2")
+	chain.slotCount[common.HexToHash(c1)] = 2
+	chain.slotCount[common.HexToHash(c2)] = 2
+	mux := muxWithChain(t, repo, pub, chain)
+
+	rec := doRequest(t, mux, http.MethodPost, "/admin/events/binary",
+		binaryEventBody("add-retry", catID, c1, fixedCondHash("add-rq1")))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("setup: %d %s", rec.Code, rec.Body.String())
+	}
+	var created eventWithMarketsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+	body := []byte(`{"markets":[{"slug":"add-retry-m2","question":"Second?","outcome_yes_label":"Yes","outcome_no_label":"No",` + tokenIDsJSON(c2) + `,"condition_id":"` + c2 + `","question_id":"` + fixedCondHash("add-rq2") + `","tick_size":"0.01","min_size":5}]}`)
+
+	pub.configErr = errors.New("KV down")
+	rec = doRequest(t, mux, http.MethodPost, "/admin/events/"+created.Event.ID+"/binary/markets", body)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("first append status = %d body=%q, want 502", rec.Code, rec.Body.String())
+	}
+	if len(repo.markets) != 2 {
+		t.Fatalf("markets after failed publish = %d, want DB append committed", len(repo.markets))
+	}
+
+	pub.configErr = nil
+	pub.configCalls = nil
+	rec = doRequest(t, mux, http.MethodPost, "/admin/events/"+created.Event.ID+"/binary/markets", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("retry status = %d body=%q, want 201", rec.Code, rec.Body.String())
+	}
+	if len(pub.configCalls) != 1 {
+		t.Errorf("config publishes on retry = %d, want 1", len(pub.configCalls))
+	}
 }
 
 // --- /admin/events/{id}/resolve -----------------------------------------

--- a/internal/platform/market/pg_repository.go
+++ b/internal/platform/market/pg_repository.go
@@ -206,6 +206,204 @@ func (repo *PGRepository) CreateEventWithMarkets(ctx context.Context, event *Eve
 	return createdEvent, createdMarkets, nil
 }
 
+// AddMarketsToEvent appends markets to an existing non-terminal event.
+// Exact existing matches are returned as idempotent no-ops so a retry after
+// DB commit + KV publish failure can republish the same market config.
+func (repo *PGRepository) AddMarketsToEvent(ctx context.Context, eventID string, markets []*Market) (*Event, []*Market, error) {
+	if len(markets) == 0 {
+		return nil, nil, fmt.Errorf("markets is empty: %w", ErrInvalidMarket)
+	}
+	if err := validateAppendMarketSet(markets); err != nil {
+		return nil, nil, err
+	}
+
+	tx, err := repo.pool.Begin(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("adding markets: beginning transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	event, err := lockEventForMarketAppend(ctx, tx, eventID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if event.Status.IsTerminal() {
+		return nil, nil, fmt.Errorf("event %s is terminal (%s): %w", eventID, event.Status.String(), ErrInvalidTransition)
+	}
+
+	addedMarkets := make([]*Market, 0, len(markets))
+	for _, market := range markets {
+		market.EventID = eventID
+		market.Status = StatusActive
+		if err := ValidateMarket(market); err != nil {
+			return nil, nil, fmt.Errorf("validating market %q: %w", market.Slug, err)
+		}
+		addedMarket, err := addOrReuseMarket(ctx, tx, eventID, market)
+		if err != nil {
+			return nil, nil, err
+		}
+		addedMarkets = append(addedMarkets, addedMarket)
+	}
+
+	updatedEvent, err := readEventInTx(ctx, tx, eventID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, nil, fmt.Errorf("adding markets: committing: %w", err)
+	}
+	return updatedEvent, addedMarkets, nil
+}
+
+func validateAppendMarketSet(markets []*Market) error {
+	seenSlugs := make(map[string]struct{}, len(markets))
+	seenConditions := make(map[string]struct{}, len(markets))
+	seenQuestions := make(map[string]struct{}, len(markets))
+	for _, market := range markets {
+		if market == nil {
+			return fmt.Errorf("market is nil: %w", ErrInvalidMarket)
+		}
+		if err := rememberAppendIdentity("slug", market.Slug, seenSlugs); err != nil {
+			return err
+		}
+		if err := rememberAppendIdentity("condition_id", market.ConditionID, seenConditions); err != nil {
+			return err
+		}
+		if err := rememberAppendIdentity("question_id", market.QuestionID, seenQuestions); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rememberAppendIdentity(name, value string, seen map[string]struct{}) error {
+	if value == "" {
+		return nil
+	}
+	if _, ok := seen[value]; ok {
+		return fmt.Errorf("duplicate market %s %q in request: %w", name, value, ErrDuplicateSlug)
+	}
+	seen[value] = struct{}{}
+	return nil
+}
+
+func lockEventForMarketAppend(ctx context.Context, tx pgx.Tx, eventID string) (*Event, error) {
+	rows, err := tx.Query(ctx, `SELECT * FROM events WHERE id = $1 FOR UPDATE`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("locking event: %w", err)
+	}
+	event, err := pgx.CollectOneRow(rows, pgx.RowToAddrOfStructByName[Event])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("event %s: %w", eventID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("locking event %s: %w", eventID, err)
+	}
+	return event, nil
+}
+
+func addOrReuseMarket(ctx context.Context, tx pgx.Tx, eventID string, market *Market) (*Market, error) {
+	existing, found, err := findExistingAppendMarket(ctx, tx, eventID, market)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		if !sameAppendMarket(existing, market) {
+			return nil, fmt.Errorf("market identity collides with existing market %s: %w", existing.ID, ErrDuplicateSlug)
+		}
+		return existing, nil
+	}
+
+	marketRows, err := tx.Query(ctx,
+		`INSERT INTO markets (
+			slug, event_id, question, outcome_yes_label, outcome_no_label,
+			token_id_yes, token_id_no, condition_id, question_id,
+			status, outcome, price_yes, price_no, volume, open_interest,
+			fee_rate_bps, tick_size, min_size, max_size
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)
+		RETURNING *`,
+		market.Slug, eventID, market.Question,
+		market.OutcomeYesLabel, market.OutcomeNoLabel,
+		market.TokenIDYes, market.TokenIDNo, market.ConditionID, market.QuestionID,
+		market.Status, market.Outcome, market.PriceYes, market.PriceNo,
+		market.Volume, market.OpenInterest,
+		market.FeeRateBps, market.TickSize, market.MinSize, market.MaxSize,
+	)
+	if err != nil {
+		if postgres.IsUniqueViolation(err) {
+			return nil, fmt.Errorf("creating market %q: %w", market.Slug, ErrDuplicateSlug)
+		}
+		return nil, fmt.Errorf("creating market %q: %w", market.Slug, err)
+	}
+	createdMarket, err := pgx.CollectOneRow(marketRows, pgx.RowToAddrOfStructByName[Market])
+	if err != nil {
+		if postgres.IsUniqueViolation(err) {
+			return nil, fmt.Errorf("creating market %q: %w", market.Slug, ErrDuplicateSlug)
+		}
+		return nil, fmt.Errorf("scanning created market %q: %w", market.Slug, err)
+	}
+	return createdMarket, nil
+}
+
+func findExistingAppendMarket(ctx context.Context, tx pgx.Tx, eventID string, market *Market) (*Market, bool, error) {
+	rows, err := tx.Query(ctx,
+		`SELECT * FROM markets
+		 WHERE event_id = $1 AND (slug = $2 OR condition_id = $3 OR question_id = $4)
+		 ORDER BY id
+		 FOR UPDATE`,
+		eventID, market.Slug, market.ConditionID, market.QuestionID,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("checking existing markets: %w", err)
+	}
+	existing, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Market])
+	if err != nil {
+		return nil, false, fmt.Errorf("scanning existing markets: %w", err)
+	}
+	if len(existing) == 0 {
+		return nil, false, nil
+	}
+	if len(existing) > 1 {
+		return nil, false, fmt.Errorf("market identity collides with multiple existing markets: %w", ErrDuplicateSlug)
+	}
+	return existing[0], true, nil
+}
+
+func sameAppendMarket(existing, requested *Market) bool {
+	return existing.EventID == requested.EventID &&
+		existing.Slug == requested.Slug &&
+		existing.Question == requested.Question &&
+		existing.OutcomeYesLabel == requested.OutcomeYesLabel &&
+		existing.OutcomeNoLabel == requested.OutcomeNoLabel &&
+		existing.TokenIDYes == requested.TokenIDYes &&
+		existing.TokenIDNo == requested.TokenIDNo &&
+		existing.ConditionID == requested.ConditionID &&
+		existing.QuestionID == requested.QuestionID &&
+		existing.TickSize == requested.TickSize &&
+		existing.MinSize == requested.MinSize &&
+		sameOptionalInt64(existing.MaxSize, requested.MaxSize) &&
+		sameOptionalInt64(existing.FeeRateBps, requested.FeeRateBps)
+}
+
+func sameOptionalInt64(left, right *int64) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func readEventInTx(ctx context.Context, tx pgx.Tx, eventID string) (*Event, error) {
+	eventRows, err := tx.Query(ctx, `SELECT * FROM events WHERE id = $1`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("re-reading event: %w", err)
+	}
+	event, err := pgx.CollectOneRow(eventRows, pgx.RowToAddrOfStructByName[Event])
+	if err != nil {
+		return nil, fmt.Errorf("scanning event: %w", err)
+	}
+	return event, nil
+}
+
 // GetEvent retrieves an event by ID. Returns ErrNotFound if not found.
 func (repo *PGRepository) GetEvent(ctx context.Context, id string) (*Event, error) {
 	rows, err := repo.pool.Query(ctx, `SELECT * FROM events WHERE id = $1`, id)

--- a/internal/platform/market/pg_repository_test.go
+++ b/internal/platform/market/pg_repository_test.go
@@ -421,6 +421,91 @@ func TestPGRepository_CreateEventWithMarkets_DuplicateEventSlug(t *testing.T) {
 	}
 }
 
+func TestPGRepository_AddMarketsToEvent_Binary(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	eventID, _ := seedBinaryEvent(t, repo, "append-binary")
+	market := defaultMarket("append-binary-new")
+
+	event, markets, err := repo.AddMarketsToEvent(ctx, eventID, []*Market{market})
+	if err != nil {
+		t.Fatalf("adding markets: %v", err)
+	}
+	if event.ID != eventID {
+		t.Errorf("event id = %q, want %q", event.ID, eventID)
+	}
+	if len(markets) != 1 {
+		t.Fatalf("markets len = %d, want 1", len(markets))
+	}
+	if markets[0].EventID != eventID {
+		t.Errorf("market.event_id = %q, want %q", markets[0].EventID, eventID)
+	}
+
+	all, err := repo.ListMarketsByEvent(ctx, eventID)
+	if err != nil {
+		t.Fatalf("listing markets: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("event markets after append = %d, want 2", len(all))
+	}
+}
+
+func TestPGRepository_AddMarketsToEvent_TerminalEventRejected(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	eventID, _ := seedBinaryEvent(t, repo, "append-terminal")
+	if _, err := pool.Exec(ctx, `UPDATE events SET status = $1 WHERE id = $2`, StatusResolved, eventID); err != nil {
+		t.Fatalf("marking event resolved: %v", err)
+	}
+
+	_, _, err := repo.AddMarketsToEvent(ctx, eventID, []*Market{defaultMarket("append-terminal-new")})
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected ErrInvalidTransition, got: %v", err)
+	}
+	all, err := repo.ListMarketsByEvent(ctx, eventID)
+	if err != nil {
+		t.Fatalf("listing markets: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("event markets after rejected append = %d, want 1", len(all))
+	}
+}
+
+func TestPGRepository_AddMarketsToEvent_IdempotentExistingMarket(t *testing.T) {
+	pool := postgres.TestPool(t)
+	cleanTables(t, pool)
+	repo := NewPGRepository(pool)
+	ctx := context.Background()
+
+	eventID, _ := seedBinaryEvent(t, repo, "append-idem")
+	market := defaultMarket("append-idem-new")
+	_, markets, err := repo.AddMarketsToEvent(ctx, eventID, []*Market{market})
+	if err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+
+	_, retried, err := repo.AddMarketsToEvent(ctx, eventID, []*Market{defaultMarket("append-idem-new")})
+	if err != nil {
+		t.Fatalf("retry add: %v", err)
+	}
+	if len(retried) != 1 || retried[0].ID != markets[0].ID {
+		t.Fatalf("retried markets = %+v, want existing market %s", retried, markets[0].ID)
+	}
+	all, err := repo.ListMarketsByEvent(ctx, eventID)
+	if err != nil {
+		t.Fatalf("listing markets: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("event markets after idempotent retry = %d, want 2", len(all))
+	}
+}
+
 func TestPGRepository_GetEvent_NotFound(t *testing.T) {
 	pool := postgres.TestPool(t)
 	cleanTables(t, pool)

--- a/internal/platform/market/repository.go
+++ b/internal/platform/market/repository.go
@@ -37,6 +37,18 @@ type Repository interface {
 	// authoritative values.
 	CreateEventWithMarkets(ctx context.Context, event *Event, markets []*Market) (*Event, []*Market, error)
 
+	// AddMarketsToEvent appends markets to an existing non-terminal event in
+	// one transaction. The event row is locked before inserts so concurrent
+	// lifecycle transitions and append attempts serialize. Returns the event
+	// row and exactly the requested markets (newly inserted or exact existing
+	// matches for idempotent retry after a failed downstream publish).
+	//
+	// Returns ErrNotFound if eventID is missing, ErrInvalidTransition if the
+	// event is terminal, ErrInvalidMarket for empty/invalid markets, and
+	// ErrDuplicateSlug when slug, condition_id, or question_id collides with
+	// a different market.
+	AddMarketsToEvent(ctx context.Context, eventID string, markets []*Market) (*Event, []*Market, error)
+
 	// GetEvent retrieves an event by ID. Returns ErrNotFound if not found.
 	GetEvent(ctx context.Context, id string) (*Event, error)
 


### PR DESCRIPTION
## Summary
- add binary and NegRisk admin endpoints for appending markets to existing events
- add transactional `AddMarketsToEvent` repository path with event row locking and idempotent retry support
- publish market config for appended markets and cover success/error/retry cases in handler + repository tests

Closes #84

## Test Plan
- `go test ./internal/platform/market -run 'TestHandler_AddMarkets' -count=1`\n- `go test ./internal/platform/market -count=1`\n- `go test -tags=integration ./internal/platform/market -run 'TestPGRepository_AddMarketsToEvent' -count=1 -p 1`\n- `go test ./...`\n- `GOFLAGS=-buildvcs=false make build`\n- `GOFLAGS=-buildvcs=false make lint`